### PR TITLE
feat: add sendBufferSize option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `sendBufferSize` config option — configurable outbound channel capacity [1, 4096], default 256
+
+---
+
 ## [0.4.0] - 2026-03-24
 
 ### Added

--- a/src/main/kotlin/com/wspulse/client/ClientConfig.kt
+++ b/src/main/kotlin/com/wspulse/client/ClientConfig.kt
@@ -57,6 +57,14 @@ class ClientConfig {
 
     /** Codec used for frame serialisation. Defaults to [JsonCodec]. */
     var codec: Codec = JsonCodec
+
+    /**
+     * Capacity of the internal send buffer (number of frames).
+     *
+     * Must be between 1 and 4096 inclusive. Larger values allow more frames
+     * to be queued during brief disconnections or bursty sends.
+     */
+    var sendBufferSize: Int = 256
 }
 
 /**

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -70,10 +70,8 @@ interface Client {
     val done: Deferred<Unit>
 }
 
-/** Internal send buffer capacity. Matches client-go (256). */
-private const val SEND_BUFFER_SIZE = 256
-
 // Configuration upper bounds — matches client-go validation ceilings.
+private const val MAX_SEND_BUFFER_SIZE = 4096
 private val MAX_PING_PERIOD = 1.minutes
 private val MAX_PONG_WAIT = 2.minutes
 private val MAX_WRITE_WAIT = 30.seconds
@@ -155,7 +153,7 @@ class WspulseClient private constructor(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /** Bounded send channel. [send] uses [Channel.trySend] (non-blocking). */
-    private val sendChannel = Channel<ByteArray>(SEND_BUFFER_SIZE)
+    private val sendChannel = Channel<ByteArray>(config.sendBufferSize)
 
     /** Completes on permanent disconnect. */
     private val _done = CompletableDeferred<Unit>()
@@ -589,6 +587,13 @@ class WspulseClient private constructor(
  * are allocated so invalid config never leaks an [HttpClient].
  */
 private fun validateConfig(config: ClientConfig) {
+    require(config.sendBufferSize >= 1) {
+        "wspulse: sendBufferSize must be at least 1"
+    }
+    require(config.sendBufferSize <= MAX_SEND_BUFFER_SIZE) {
+        "wspulse: sendBufferSize exceeds maximum (4096)"
+    }
+
     require(config.maxMessageSize >= 0) {
         "wspulse: maxMessageSize must be non-negative"
     }

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -591,7 +591,7 @@ private fun validateConfig(config: ClientConfig) {
         "wspulse: sendBufferSize must be at least 1"
     }
     require(config.sendBufferSize <= MAX_SEND_BUFFER_SIZE) {
-        "wspulse: sendBufferSize exceeds maximum (4096)"
+        "wspulse: sendBufferSize exceeds maximum ($MAX_SEND_BUFFER_SIZE)"
     }
 
     require(config.maxMessageSize >= 0) {

--- a/src/test/kotlin/com/wspulse/client/ConfigValidationTest.kt
+++ b/src/test/kotlin/com/wspulse/client/ConfigValidationTest.kt
@@ -14,6 +14,67 @@ import kotlin.time.Duration.Companion.seconds
  * Matches client-go's fail-fast validation in option functions.
  */
 class ConfigValidationTest {
+    // ── sendBufferSize ──────────────────────────────────────────────────────
+
+    @Test
+    fun `sendBufferSize 1 is valid`() {
+        val ex =
+            assertThrows<Exception> {
+                runBlocking {
+                    WspulseClient.connect("ws://127.0.0.1:1") {
+                        sendBufferSize = 1
+                    }
+                }
+            }
+        assertFalse(ex is IllegalArgumentException, "sendBufferSize=1 should be valid")
+    }
+
+    @Test
+    fun `sendBufferSize 4096 is valid`() {
+        val ex =
+            assertThrows<Exception> {
+                runBlocking {
+                    WspulseClient.connect("ws://127.0.0.1:1") {
+                        sendBufferSize = 4096
+                    }
+                }
+            }
+        assertFalse(ex is IllegalArgumentException, "sendBufferSize=4096 should be valid")
+    }
+
+    @Test
+    fun `sendBufferSize zero throws`() {
+        assertThrows<IllegalArgumentException> {
+            runBlocking {
+                WspulseClient.connect("ws://127.0.0.1:1") {
+                    sendBufferSize = 0
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `negative sendBufferSize throws`() {
+        assertThrows<IllegalArgumentException> {
+            runBlocking {
+                WspulseClient.connect("ws://127.0.0.1:1") {
+                    sendBufferSize = -1
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `sendBufferSize exceeding 4096 throws`() {
+        assertThrows<IllegalArgumentException> {
+            runBlocking {
+                WspulseClient.connect("ws://127.0.0.1:1") {
+                    sendBufferSize = 4097
+                }
+            }
+        }
+    }
+
     // ── maxMessageSize ──────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Add `sendBufferSize` option to make the outbound channel capacity configurable. Previously hardcoded at 256, now matches server and client-go's `WithSendBufferSize` API.

## Changes

- Add `sendBufferSize` to `ClientConfig` DSL (default 256, range [1, 4096])
- Add validation in `validateConfig`: throws `IllegalArgumentException` if < 1 or > 4096
- Replace hardcoded channel capacity with configured value
- Add tests: valid values, zero/negative/exceeds-max throws

## Checklist

### Required

- [x] `make check` passes (lint → test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] New public API: includes KDoc comments