### PR TITLE
feat: auto-convert HTTP URL schemes in connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `connect()` auto-converts `http://` to `ws://` and `https://` to `wss://` (case-insensitive per RFC 3986). Other schemes are passed through to the underlying Ktor transport.
+- `connect()` auto-converts `http://` to `ws://` and `https://` to `wss://` (case-insensitive per RFC 3986). Unsupported or missing schemes throw `IllegalArgumentException`.
 - `sendBufferSize` config option — configurable outbound channel capacity [1, 4096], default 256
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `connect()` auto-converts `http://` → `ws://` and `https://` → `wss://` URL schemes. Missing or unsupported schemes throw `IllegalArgumentException`.
 - `sendBufferSize` config option — configurable outbound channel capacity [1, 4096], default 256
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `connect()` auto-converts `http://` → `ws://` and `https://` → `wss://` URL schemes. Missing or unsupported schemes throw `IllegalArgumentException`.
+- `connect()` auto-converts `http://` → `ws://` and `https://` → `wss://` URL schemes
 - `sendBufferSize` config option — configurable outbound channel capacity [1, 4096], default 256
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `connect()` auto-converts `http://` → `ws://` and `https://` → `wss://` URL schemes
+- `connect()` auto-converts `http://` to `ws://` and `https://` to `wss://` (case-insensitive per RFC 3986). Other schemes are passed through to the underlying Ktor transport.
 - `sendBufferSize` config option — configurable outbound channel capacity [1, 4096], default 256
 
 ---

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -590,11 +590,8 @@ class WspulseClient private constructor(
  * `ws://` and `wss://` pass through unchanged.
  * Any other scheme (or missing scheme) throws [IllegalArgumentException].
  *
- * Unlike client-go and client-ts which delegate scheme validation to the
- * underlying WebSocket library, client-kt validates explicitly because
- * Ktor's error messages for invalid schemes are generic and unhelpful.
- * client-swift also validates explicitly for a different reason:
- * URLSessionWebSocketTask raises an uncatchable NSException.
+ * Validates explicitly because Ktor's error messages for invalid
+ * schemes are generic and unhelpful.
  */
 private fun normalizeScheme(url: String): String {
     val lower = url.lowercase()

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -589,6 +589,12 @@ class WspulseClient private constructor(
  * Converts `http://` to `ws://` and `https://` to `wss://`.
  * `ws://` and `wss://` pass through unchanged.
  * Any other scheme (or missing scheme) throws [IllegalArgumentException].
+ *
+ * Unlike client-go and client-ts which delegate scheme validation to the
+ * underlying WebSocket library, client-kt validates explicitly because
+ * Ktor's error messages for invalid schemes are generic and unhelpful.
+ * client-swift also validates explicitly for a different reason:
+ * URLSessionWebSocketTask raises an uncatchable NSException.
  */
 private fun normalizeScheme(url: String): String {
     val lower = url.lowercase()

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -594,14 +594,30 @@ private fun normalizeScheme(url: String): String {
         try {
             URI(url)
         } catch (e: Exception) {
-            throw IllegalArgumentException(
-                "wspulse: url must include scheme (ws://, wss://, http://, or https://)",
-            )
+            throw IllegalArgumentException("wspulse: invalid url", e)
         }
     return when (parsed.scheme?.lowercase()) {
         "ws", "wss" -> url
-        "http" -> url.replaceFirst("http://", "ws://")
-        "https" -> url.replaceFirst("https://", "wss://")
+        "http" ->
+            URI(
+                "ws",
+                parsed.userInfo,
+                parsed.host,
+                parsed.port,
+                parsed.path,
+                parsed.query,
+                parsed.fragment,
+            ).toString()
+        "https" ->
+            URI(
+                "wss",
+                parsed.userInfo,
+                parsed.host,
+                parsed.port,
+                parsed.path,
+                parsed.query,
+                parsed.fragment,
+            ).toString()
         null -> throw IllegalArgumentException(
             "wspulse: url must include scheme (ws://, wss://, http://, or https://)",
         )

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.slf4j.LoggerFactory
+import java.net.URI
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -116,6 +117,7 @@ class WspulseClient private constructor(
             url: String,
             init: ClientConfig.() -> Unit = {},
         ): Client {
+            val normalizedUrl = normalizeScheme(url)
             val config = ClientConfig().apply(init)
             validateConfig(config)
             val httpClient =
@@ -123,7 +125,7 @@ class WspulseClient private constructor(
                     install(WebSockets)
                 }
 
-            val client = WspulseClient(url, config, httpClient)
+            val client = WspulseClient(normalizedUrl, config, httpClient)
 
             try {
                 val session = client.dialOnce()
@@ -577,6 +579,36 @@ class WspulseClient private constructor(
 
         // Resolve done.
         _done.complete(Unit)
+    }
+}
+
+/**
+ * Normalize the URL scheme for WebSocket connections.
+ *
+ * Converts `http://` to `ws://` and `https://` to `wss://`.
+ * Passes `ws://` and `wss://` through unchanged. Throws
+ * [IllegalArgumentException] for missing or unsupported schemes.
+ */
+private fun normalizeScheme(url: String): String {
+    val parsed =
+        try {
+            URI(url)
+        } catch (e: Exception) {
+            throw IllegalArgumentException(
+                "wspulse: url must include scheme (ws://, wss://, http://, or https://)",
+            )
+        }
+    return when (parsed.scheme?.lowercase()) {
+        "ws", "wss" -> url
+        "http" -> url.replaceFirst("http://", "ws://")
+        "https" -> url.replaceFirst("https://", "wss://")
+        null -> throw IllegalArgumentException(
+            "wspulse: url must include scheme (ws://, wss://, http://, or https://)",
+        )
+        else -> throw IllegalArgumentException(
+            "wspulse: unsupported url scheme \"${parsed.scheme}\", " +
+                "use ws://, wss://, http://, or https://",
+        )
     }
 }
 

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -106,7 +106,9 @@ class WspulseClient private constructor(
          * no [Client] is returned to the caller. Auto-reconnect only activates
          * after a successful initial connection subsequently drops.
          *
-         * @param url  WebSocket URL (e.g. `wss://host/ws`)
+         * @param url  WebSocket or HTTP URL (e.g. `wss://host/ws`).
+         *             `http://` and `https://` schemes are auto-converted
+         *             to `ws://` and `wss://` respectively.
          * @param init DSL block to configure the client.
          * @return A [Client] whose initial WebSocket handshake has completed
          *         successfully. The underlying transport is connected on a
@@ -598,26 +600,8 @@ private fun normalizeScheme(url: String): String {
         }
     return when (parsed.scheme?.lowercase()) {
         "ws", "wss" -> url
-        "http" ->
-            URI(
-                "ws",
-                parsed.userInfo,
-                parsed.host,
-                parsed.port,
-                parsed.path,
-                parsed.query,
-                parsed.fragment,
-            ).toString()
-        "https" ->
-            URI(
-                "wss",
-                parsed.userInfo,
-                parsed.host,
-                parsed.port,
-                parsed.path,
-                parsed.query,
-                parsed.fragment,
-            ).toString()
+        "http" -> url.replaceFirst(Regex("^http", RegexOption.IGNORE_CASE), "ws")
+        "https" -> url.replaceFirst(Regex("^https", RegexOption.IGNORE_CASE), "wss")
         null -> throw IllegalArgumentException(
             "wspulse: url must include scheme (ws://, wss://, http://, or https://)",
         )

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -587,17 +587,29 @@ class WspulseClient private constructor(
  * Normalize the URL scheme for WebSocket connections.
  *
  * Converts `http://` to `ws://` and `https://` to `wss://`.
- * All other schemes (including `ws://` and `wss://`) pass through
- * unchanged — Ktor validates the final URL.
+ * `ws://` and `wss://` pass through unchanged.
+ * Any other scheme (or missing scheme) throws [IllegalArgumentException].
  */
-private fun normalizeScheme(url: String): String =
-    when {
-        url.startsWith("https://", ignoreCase = true) ->
-            "wss://" + url.substring("https://".length)
-        url.startsWith("http://", ignoreCase = true) ->
-            "ws://" + url.substring("http://".length)
-        else -> url
+private fun normalizeScheme(url: String): String {
+    val lower = url.lowercase()
+    return when {
+        lower.startsWith("https://") -> "wss://" + url.substring("https://".length)
+        lower.startsWith("http://") -> "ws://" + url.substring("http://".length)
+        lower.startsWith("wss://") || lower.startsWith("ws://") -> url
+        else -> {
+            val schemeEnd = url.indexOf("://")
+            if (schemeEnd > 0) {
+                throw IllegalArgumentException(
+                    "wspulse: unsupported url scheme \"${url.substring(0, schemeEnd)}\"," +
+                        " use ws://, wss://, http://, or https://",
+                )
+            }
+            throw IllegalArgumentException(
+                "wspulse: url must include scheme (ws://, wss://, http://, or https://)",
+            )
+        }
     }
+}
 
 /**
  * Validate [ClientConfig] values against upper bounds.

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.slf4j.LoggerFactory
-import java.net.URI
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -588,29 +587,17 @@ class WspulseClient private constructor(
  * Normalize the URL scheme for WebSocket connections.
  *
  * Converts `http://` to `ws://` and `https://` to `wss://`.
- * Passes `ws://` and `wss://` through unchanged. Throws
- * [IllegalArgumentException] for missing or unsupported schemes.
+ * All other schemes (including `ws://` and `wss://`) pass through
+ * unchanged — Ktor validates the final URL.
  */
-private fun normalizeScheme(url: String): String {
-    val parsed =
-        try {
-            URI(url)
-        } catch (e: Exception) {
-            throw IllegalArgumentException("wspulse: invalid url", e)
-        }
-    return when (parsed.scheme?.lowercase()) {
-        "ws", "wss" -> url
-        "http" -> url.replaceFirst(Regex("^http", RegexOption.IGNORE_CASE), "ws")
-        "https" -> url.replaceFirst(Regex("^https", RegexOption.IGNORE_CASE), "wss")
-        null -> throw IllegalArgumentException(
-            "wspulse: url must include scheme (ws://, wss://, http://, or https://)",
-        )
-        else -> throw IllegalArgumentException(
-            "wspulse: unsupported url scheme \"${parsed.scheme}\", " +
-                "use ws://, wss://, http://, or https://",
-        )
+private fun normalizeScheme(url: String): String =
+    when {
+        url.startsWith("https://", ignoreCase = true) ->
+            "wss://" + url.substring("https://".length)
+        url.startsWith("http://", ignoreCase = true) ->
+            "ws://" + url.substring("http://".length)
+        else -> url
     }
-}
 
 /**
  * Validate [ClientConfig] values against upper bounds.

--- a/src/test/kotlin/com/wspulse/client/NormalizeSchemeTest.kt
+++ b/src/test/kotlin/com/wspulse/client/NormalizeSchemeTest.kt
@@ -3,19 +3,17 @@ package com.wspulse.client
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import kotlin.test.assertContains
 import kotlin.test.assertFalse
 
 /**
  * Tests for URL scheme normalization in [WspulseClient.connect].
  *
  * The normalization function converts `http://` to `ws://` and
- * `https://` to `wss://`, passes `ws://` and `wss://` through
- * unchanged, and throws [IllegalArgumentException] for missing
- * or unsupported schemes.
+ * `https://` to `wss://`. All other schemes pass through unchanged
+ * — Ktor validates the final URL.
  *
  * Tests use port 1 (unreachable) to trigger a dial failure after
- * validation passes, proving that scheme validation did not reject.
+ * normalization, proving that the scheme was accepted.
  */
 class NormalizeSchemeTest {
     // ── passthrough ────────────────────────────────────────────────────────
@@ -147,50 +145,6 @@ class NormalizeSchemeTest {
         assertFalse(
             ex is IllegalArgumentException,
             "WS:// should pass through without error",
-        )
-    }
-
-    // ── error cases ────────────────────────────────────────────────────────
-
-    @Test
-    fun `missing scheme throws`() {
-        val ex =
-            assertThrows<IllegalArgumentException> {
-                runBlocking {
-                    WspulseClient.connect("/no-scheme/path")
-                }
-            }
-        assertContains(
-            ex.message ?: "",
-            "wspulse: url must include scheme",
-        )
-    }
-
-    @Test
-    fun `unsupported scheme throws`() {
-        val ex =
-            assertThrows<IllegalArgumentException> {
-                runBlocking {
-                    WspulseClient.connect("ftp://127.0.0.1:1/ws")
-                }
-            }
-        assertContains(
-            ex.message ?: "",
-            "wspulse: unsupported url scheme",
-        )
-    }
-
-    @Test
-    fun `malformed url throws invalid url`() {
-        val ex =
-            assertThrows<IllegalArgumentException> {
-                runBlocking {
-                    WspulseClient.connect("://no-scheme")
-                }
-            }
-        assertContains(
-            ex.message ?: "",
-            "wspulse: invalid url",
         )
     }
 }

--- a/src/test/kotlin/com/wspulse/client/NormalizeSchemeTest.kt
+++ b/src/test/kotlin/com/wspulse/client/NormalizeSchemeTest.kt
@@ -10,8 +10,9 @@ import kotlin.test.assertTrue
  * Tests for URL scheme normalization in [WspulseClient.connect].
  *
  * The normalization function converts `http://` to `ws://` and
- * `https://` to `wss://`. All other schemes pass through unchanged
- * — Ktor validates the final URL.
+ * `https://` to `wss://`. Unsupported schemes throw
+ * [IllegalArgumentException], and missing schemes throw
+ * [IllegalArgumentException].
  *
  * Tests use port 1 (unreachable) to trigger a dial failure after
  * normalization, proving that the scheme was accepted.

--- a/src/test/kotlin/com/wspulse/client/NormalizeSchemeTest.kt
+++ b/src/test/kotlin/com/wspulse/client/NormalizeSchemeTest.kt
@@ -79,20 +79,6 @@ class NormalizeSchemeTest {
     }
 
     @Test
-    fun `http with port converts to ws`() {
-        val ex =
-            assertThrows<Exception> {
-                runBlocking {
-                    WspulseClient.connect("http://127.0.0.1:1/ws")
-                }
-            }
-        assertFalse(
-            ex is IllegalArgumentException,
-            "http:// with port should be accepted and converted to ws://",
-        )
-    }
-
-    @Test
     fun `https with port and query converts to wss`() {
         val ex =
             assertThrows<Exception> {
@@ -103,6 +89,20 @@ class NormalizeSchemeTest {
         assertFalse(
             ex is IllegalArgumentException,
             "https:// with port and query should be accepted and converted to wss://",
+        )
+    }
+
+    @Test
+    fun `https with percent-encoded reserved chars preserves encoding`() {
+        val ex =
+            assertThrows<Exception> {
+                runBlocking {
+                    WspulseClient.connect("https://127.0.0.1:1/ws%2Fsegment?q=a%2Fb")
+                }
+            }
+        assertFalse(
+            ex is IllegalArgumentException,
+            "https:// with percent-encoded reserved characters should be accepted",
         )
     }
 

--- a/src/test/kotlin/com/wspulse/client/NormalizeSchemeTest.kt
+++ b/src/test/kotlin/com/wspulse/client/NormalizeSchemeTest.kt
@@ -83,7 +83,7 @@ class NormalizeSchemeTest {
         val ex =
             assertThrows<Exception> {
                 runBlocking {
-                    WspulseClient.connect("http://127.0.0.1:8080/ws")
+                    WspulseClient.connect("http://127.0.0.1:1/ws")
                 }
             }
         assertFalse(
@@ -106,6 +106,50 @@ class NormalizeSchemeTest {
         )
     }
 
+    // ── mixed case schemes ───────────────────────────────────────────────
+
+    @Test
+    fun `HTTP uppercase converts to ws`() {
+        val ex =
+            assertThrows<Exception> {
+                runBlocking {
+                    WspulseClient.connect("HTTP://127.0.0.1:1/ws")
+                }
+            }
+        assertFalse(
+            ex is IllegalArgumentException,
+            "HTTP:// should be accepted and converted to ws://",
+        )
+    }
+
+    @Test
+    fun `Https mixed case converts to wss`() {
+        val ex =
+            assertThrows<Exception> {
+                runBlocking {
+                    WspulseClient.connect("Https://127.0.0.1:1/ws")
+                }
+            }
+        assertFalse(
+            ex is IllegalArgumentException,
+            "Https:// should be accepted and converted to wss://",
+        )
+    }
+
+    @Test
+    fun `WS uppercase passes through`() {
+        val ex =
+            assertThrows<Exception> {
+                runBlocking {
+                    WspulseClient.connect("WS://127.0.0.1:1/ws")
+                }
+            }
+        assertFalse(
+            ex is IllegalArgumentException,
+            "WS:// should pass through without error",
+        )
+    }
+
     // ── error cases ────────────────────────────────────────────────────────
 
     @Test
@@ -113,7 +157,7 @@ class NormalizeSchemeTest {
         val ex =
             assertThrows<IllegalArgumentException> {
                 runBlocking {
-                    WspulseClient.connect("127.0.0.1:1/ws")
+                    WspulseClient.connect("/no-scheme/path")
                 }
             }
         assertContains(
@@ -133,6 +177,20 @@ class NormalizeSchemeTest {
         assertContains(
             ex.message ?: "",
             "wspulse: unsupported url scheme",
+        )
+    }
+
+    @Test
+    fun `malformed url throws invalid url`() {
+        val ex =
+            assertThrows<IllegalArgumentException> {
+                runBlocking {
+                    WspulseClient.connect("://no-scheme")
+                }
+            }
+        assertContains(
+            ex.message ?: "",
+            "wspulse: invalid url",
         )
     }
 }

--- a/src/test/kotlin/com/wspulse/client/NormalizeSchemeTest.kt
+++ b/src/test/kotlin/com/wspulse/client/NormalizeSchemeTest.kt
@@ -1,0 +1,138 @@
+package com.wspulse.client
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+/**
+ * Tests for URL scheme normalization in [WspulseClient.connect].
+ *
+ * The normalization function converts `http://` to `ws://` and
+ * `https://` to `wss://`, passes `ws://` and `wss://` through
+ * unchanged, and throws [IllegalArgumentException] for missing
+ * or unsupported schemes.
+ *
+ * Tests use port 1 (unreachable) to trigger a dial failure after
+ * validation passes, proving that scheme validation did not reject.
+ */
+class NormalizeSchemeTest {
+    // ── passthrough ────────────────────────────────────────────────────────
+
+    @Test
+    fun `ws scheme passes through`() {
+        val ex =
+            assertThrows<Exception> {
+                runBlocking {
+                    WspulseClient.connect("ws://127.0.0.1:1/ws")
+                }
+            }
+        assertFalse(
+            ex is IllegalArgumentException,
+            "ws:// should pass through without error",
+        )
+    }
+
+    @Test
+    fun `wss scheme passes through`() {
+        val ex =
+            assertThrows<Exception> {
+                runBlocking {
+                    WspulseClient.connect("wss://127.0.0.1:1/ws")
+                }
+            }
+        assertFalse(
+            ex is IllegalArgumentException,
+            "wss:// should pass through without error",
+        )
+    }
+
+    // ── http → ws conversion ───────────────────────────────────────────────
+
+    @Test
+    fun `http converts to ws`() {
+        val ex =
+            assertThrows<Exception> {
+                runBlocking {
+                    WspulseClient.connect("http://127.0.0.1:1/ws")
+                }
+            }
+        assertFalse(
+            ex is IllegalArgumentException,
+            "http:// should be accepted and converted to ws://",
+        )
+    }
+
+    @Test
+    fun `https converts to wss`() {
+        val ex =
+            assertThrows<Exception> {
+                runBlocking {
+                    WspulseClient.connect("https://127.0.0.1:1/ws")
+                }
+            }
+        assertFalse(
+            ex is IllegalArgumentException,
+            "https:// should be accepted and converted to wss://",
+        )
+    }
+
+    @Test
+    fun `http with port converts to ws`() {
+        val ex =
+            assertThrows<Exception> {
+                runBlocking {
+                    WspulseClient.connect("http://127.0.0.1:8080/ws")
+                }
+            }
+        assertFalse(
+            ex is IllegalArgumentException,
+            "http:// with port should be accepted and converted to ws://",
+        )
+    }
+
+    @Test
+    fun `https with port and query converts to wss`() {
+        val ex =
+            assertThrows<Exception> {
+                runBlocking {
+                    WspulseClient.connect("https://127.0.0.1:1/ws?token=abc")
+                }
+            }
+        assertFalse(
+            ex is IllegalArgumentException,
+            "https:// with port and query should be accepted and converted to wss://",
+        )
+    }
+
+    // ── error cases ────────────────────────────────────────────────────────
+
+    @Test
+    fun `missing scheme throws`() {
+        val ex =
+            assertThrows<IllegalArgumentException> {
+                runBlocking {
+                    WspulseClient.connect("127.0.0.1:1/ws")
+                }
+            }
+        assertContains(
+            ex.message ?: "",
+            "wspulse: url must include scheme",
+        )
+    }
+
+    @Test
+    fun `unsupported scheme throws`() {
+        val ex =
+            assertThrows<IllegalArgumentException> {
+                runBlocking {
+                    WspulseClient.connect("ftp://127.0.0.1:1/ws")
+                }
+            }
+        assertContains(
+            ex.message ?: "",
+            "wspulse: unsupported url scheme",
+        )
+    }
+}

--- a/src/test/kotlin/com/wspulse/client/NormalizeSchemeTest.kt
+++ b/src/test/kotlin/com/wspulse/client/NormalizeSchemeTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Tests for URL scheme normalization in [WspulseClient.connect].
@@ -146,5 +147,25 @@ class NormalizeSchemeTest {
             ex is IllegalArgumentException,
             "WS:// should pass through without error",
         )
+    }
+
+    // ── invalid schemes ─────────────────────────────────────────────────────
+
+    @Test
+    fun `unsupported scheme throws`() {
+        val ex =
+            assertThrows<IllegalArgumentException> {
+                runBlocking { WspulseClient.connect("ftp://host/ws") }
+            }
+        assertTrue(ex.message!!.contains("unsupported url scheme"))
+    }
+
+    @Test
+    fun `missing scheme throws`() {
+        val ex =
+            assertThrows<IllegalArgumentException> {
+                runBlocking { WspulseClient.connect("host/ws") }
+            }
+        assertTrue(ex.message!!.contains("url must include scheme"))
     }
 }


### PR DESCRIPTION
## Summary

`connect()` now accepts `http://` and `https://` URLs, automatically converting them to `ws://` and `wss://`. Missing or unsupported schemes throw `IllegalArgumentException`.

## Changes

- Add `normalizeScheme()` private function for URL scheme conversion (`http://` → `ws://`, `https://` → `wss://`)
- Call `normalizeScheme()` at the top of `connect()` before config processing or resource allocation
- Add `NormalizeSchemeTest` with 8 unit tests: ws/wss passthrough, http/https conversion, http with port, https with port and query, missing scheme throws, unsupported scheme throws
- Add CHANGELOG `[Unreleased]` entry

## Checklist

### Required

- [x] `make check` passes (lint → test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] New public API: includes KDoc comments

---
Relates to wspulse/.github#8