### PR TITLE
feat: remove Frame.ID field

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ wspulse/client-kt is a **WebSocket client library for Kotlin (JVM + Android)** w
 - **`WspulseClient.kt`** — `Client` interface (public API: `send`, `close`, `done`) and `WspulseClient.connect()` companion factory. Internal coroutines: `readLoop`, `writeLoop`, `reconnectLoop`, `pingLoop`.
 - **`ClientConfig.kt`** — Builder DSL for configuration (callbacks, reconnect, heartbeat, codec).
 - **`Codec.kt`** — `Codec` interface, `FrameType` enum, `JsonCodec` default implementation.
-- **`Frame.kt`** — `data class Frame(id, event, payload: Any?)`.
+- **`Frame.kt`** — `data class Frame(event, payload: Any?)`.
 - **`Errors.kt`** — `sealed class WspulseException` hierarchy.
 - **`Backoff.kt`** — `backoff(attempt, base, max): Duration` with equal jitter.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ making any changes.
   `readLoop` / `writeLoop` / `reconnectLoop` / `pingLoop` coroutines
 - `ClientConfig.kt` — Builder DSL for configuration
 - `Codec.kt` — `Codec` interface, `FrameType` enum, `JsonCodec` default
-- `Frame.kt` — `data class Frame(id, event, payload)`
+- `Frame.kt` — `data class Frame(event, payload)`
 - `Errors.kt` — `sealed class WspulseException` hierarchy
 - `Backoff.kt` — `backoff(attempt, base, max)` with equal jitter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `sendBufferSize` config option — configurable outbound channel capacity [1, 4096], default 256
 
+### Changed
+
+- `Frame.id` field removed — transport layer does not use it. Applications needing message IDs should use payload.
+
 ---
 
 ## [0.4.0] - 2026-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 - `sendBufferSize` config option — configurable outbound channel capacity [1, 4096], default 256
 
-### Changed
+### Removed
 
-- `Frame.id` field removed — transport layer does not use it. Applications needing message IDs should use payload.
+- **BREAKING**: `Frame.id` field removed — transport layer does not use it. Applications needing message IDs should use payload.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ The default `JsonCodec` encodes frames as JSON text frames:
 
 ```json
 {
-  "id": "msg-001",
   "event": "chat.message",
   "payload": { "text": "hello" }
 }

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ val client = WspulseClient.connect(url) {
 | --------------- | ---------------------------------------------------- |
 | `Client`        | Interface: `send()`, `close()`, `done`               |
 | `WspulseClient` | Implementation with `companion object { connect() }` |
-| `Frame`         | Data class: `id?`, `event?`, `payload?`              |
+| `Frame`         | Data class: `event?`, `payload?`                     |
 | `Codec`         | Interface: `encode()`, `decode()`, `frameType`       |
 | `JsonCodec`     | Default codec — JSON text frames                     |
 | `ClientConfig`  | Builder DSL for client configuration                 |

--- a/doc/integration-tests.md
+++ b/doc/integration-tests.md
@@ -27,7 +27,7 @@ Integration tests run against a live `wspulse/server` via the shared
 
 | Test Name                                           | What It Covers                               |
 | --------------------------------------------------- | -------------------------------------------- |
-| `round-trips all Frame fields (id, event, payload)` | Full Frame field fidelity through the wire   |
+| `round-trips all Frame fields (event, payload)`     | Full Frame field fidelity through the wire   |
 | `handles server rejection gracefully`               | Server returns HTTP 403 via `?reject=1`      |
 | `sends multiple frames and receives them in order`  | Message ordering preservation                |
 | `connects to a specific room via query param`       | Room routing via `?room=…`                   |

--- a/src/main/kotlin/com/wspulse/client/Codec.kt
+++ b/src/main/kotlin/com/wspulse/client/Codec.kt
@@ -22,9 +22,9 @@ interface Codec {
 /**
  * Default JSON codec using `org.json`.
  *
- * Encodes [Frame] fields as a JSON object with keys `"id"`, `"event"`, and
- * `"payload"`. Null fields are omitted from the output. On decode, unknown
- * keys are silently ignored.
+ * Encodes [Frame] fields as a JSON object with keys `"event"` and `"payload"`.
+ * Null fields are omitted from the output. On decode, unknown keys are
+ * silently ignored.
  *
  * Payload values are recursively converted between `org.json` types and Kotlin
  * stdlib types ([Map], [List], [String], [Number], [Boolean], `null`).
@@ -34,7 +34,6 @@ object JsonCodec : Codec {
 
     override fun encode(frame: Frame): ByteArray {
         val obj = JSONObject()
-        frame.id?.let { obj.put("id", it) }
         frame.event?.let { obj.put("event", it) }
         frame.payload?.let { obj.put("payload", toJson(it)) }
         return obj.toString().toByteArray(Charsets.UTF_8)
@@ -43,7 +42,6 @@ object JsonCodec : Codec {
     override fun decode(data: ByteArray): Frame {
         val obj = JSONObject(String(data, Charsets.UTF_8))
         return Frame(
-            id = obj.opt("id") as? String,
             event = obj.opt("event") as? String,
             payload = obj.opt("payload")?.let { fromJson(it) },
         )

--- a/src/main/kotlin/com/wspulse/client/Frame.kt
+++ b/src/main/kotlin/com/wspulse/client/Frame.kt
@@ -8,7 +8,6 @@ package com.wspulse.client
  * serialisation — [JsonCodec] enforces this contract.
  */
 data class Frame(
-    val id: String? = null,
     val event: String? = null,
     val payload: Any? = null,
 )

--- a/src/test/kotlin/com/wspulse/client/ClientIntegrationTest.kt
+++ b/src/test/kotlin/com/wspulse/client/ClientIntegrationTest.kt
@@ -198,7 +198,7 @@ class ClientIntegrationTest {
         }
 
     @Test
-    fun `round-trips all Frame fields (id, event, payload)`() =
+    fun `round-trips all Frame fields (event, payload)`() =
         runTest {
             val received = CopyOnWriteArrayList<Frame>()
 
@@ -210,7 +210,6 @@ class ClientIntegrationTest {
 
             val outbound =
                 Frame(
-                    id = "test-id-001",
                     event = "chat.message",
                     payload =
                         mapOf(

--- a/src/test/kotlin/com/wspulse/client/CodecTest.kt
+++ b/src/test/kotlin/com/wspulse/client/CodecTest.kt
@@ -8,10 +8,9 @@ import kotlin.test.assertNull
 class CodecTest {
     @Test
     fun `round-trip encode and decode`() {
-        val frame = Frame(id = "abc", event = "chat", payload = mapOf("msg" to "hello"))
+        val frame = Frame(event = "chat", payload = mapOf("msg" to "hello"))
         val decoded = JsonCodec.decode(JsonCodec.encode(frame))
 
-        assertEquals("abc", decoded.id)
         assertEquals("chat", decoded.event)
         assertEquals(mapOf("msg" to "hello"), decoded.payload)
     }
@@ -26,10 +25,9 @@ class CodecTest {
 
     @Test
     fun `unknown keys in JSON are ignored on decode`() {
-        val json = """{"id":"1","event":"e","payload":"v","extra":"ignored"}"""
+        val json = """{"event":"e","payload":"v","extra":"ignored"}"""
         val frame = JsonCodec.decode(json.toByteArray(Charsets.UTF_8))
 
-        assertEquals("1", frame.id)
         assertEquals("e", frame.event)
         assertEquals("v", frame.payload)
     }
@@ -58,7 +56,6 @@ class CodecTest {
     fun `empty frame decodes from empty JSON object`() {
         val frame = JsonCodec.decode("{}".toByteArray(Charsets.UTF_8))
 
-        assertNull(frame.id)
         assertNull(frame.event)
         assertNull(frame.payload)
     }


### PR DESCRIPTION
## Summary

Remove `Frame.id` field — transport layer does not use it.

## Changes

- Remove `id` from Frame data class
- Remove `id` from Codec encode/decode
- Update tests
- CHANGELOG entry added

## Checklist

### Required

- [x] `make check` passes (lint → test)
- [x] Each commit represents exactly one logical change
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: v0, intentional before API freeze

---
Relates to wspulse/.github#9