### PR TITLE
refactor: encapsulate Ktor types behind Transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 
+- Internal: replaced Ktor `Frame` and `CloseReason` types in `Transport` interface with library-owned `TransportFrame` (sealed class) and `TransportCloseReason`. Ktor types are now fully encapsulated inside `RealTransport`. No public API changes.
 - Migrated integration tests to deterministic component tests using mock transport (no network I/O, no testserver dependency). 17 component tests replace 16 integration tests.
 - Internal: extracted `Transport` and `Dialer` interfaces from `DefaultWebSocketSession` usage. Internal visibility only -- no public API changes.
 - CI: removed `test-integration` job; component tests run in `lint-test`

--- a/src/main/kotlin/com/wspulse/client/Transport.kt
+++ b/src/main/kotlin/com/wspulse/client/Transport.kt
@@ -1,26 +1,27 @@
 package com.wspulse.client
 
-import io.ktor.websocket.CloseReason
 import kotlinx.coroutines.channels.ReceiveChannel
-import io.ktor.websocket.Frame as WsFrame
 
 /**
  * Abstraction over the raw WebSocket session.
  *
- * Production code uses [RealTransport] (wraps Ktor [io.ktor.websocket.DefaultWebSocketSession]).
+ * Production code uses [RealTransport] (wraps Ktor's DefaultWebSocketSession).
  * Tests inject a mock implementation to eliminate network I/O.
+ *
+ * All frame types use library-owned [TransportFrame] — no transport library
+ * types leak through this interface.
  *
  * Internal visibility -- not part of the public API.
  */
 internal interface Transport {
     /** Channel of incoming WebSocket frames. */
-    val incoming: ReceiveChannel<WsFrame>
+    val incoming: ReceiveChannel<TransportFrame>
 
     /** Send a WebSocket frame. */
-    suspend fun send(frame: WsFrame)
+    suspend fun send(frame: TransportFrame)
 
     /** Close the transport with the given reason. */
-    suspend fun close(reason: CloseReason = CloseReason(CloseReason.Codes.NORMAL, ""))
+    suspend fun close(reason: TransportCloseReason = TransportCloseReason.NORMAL)
 }
 
 /**

--- a/src/main/kotlin/com/wspulse/client/TransportFrame.kt
+++ b/src/main/kotlin/com/wspulse/client/TransportFrame.kt
@@ -70,7 +70,16 @@ internal data class TransportCloseReason(
         /** Normal closure (1000). */
         val NORMAL = TransportCloseReason(1000, "")
 
-        /** Going away (1001) — used for reconnect and pong timeout. */
-        val GOING_AWAY = TransportCloseReason(1001, "")
+        /** Reconnecting (1001) — client is about to reconnect. */
+        val RECONNECTING = TransportCloseReason(1001, "reconnecting")
+
+        /** Write error (1001) — send failed, dropping connection. */
+        val WRITE_ERROR = TransportCloseReason(1001, "write error")
+
+        /** Pong timeout (1001) — server did not respond to ping in time. */
+        val PONG_TIMEOUT = TransportCloseReason(1001, "pong timeout")
+
+        /** Message too large (1009) — received frame exceeds size limit. */
+        val MESSAGE_TOO_LARGE = TransportCloseReason(1009, "message too large")
     }
 }

--- a/src/main/kotlin/com/wspulse/client/TransportFrame.kt
+++ b/src/main/kotlin/com/wspulse/client/TransportFrame.kt
@@ -1,0 +1,76 @@
+package com.wspulse.client
+
+/**
+ * Library-owned WebSocket frame abstraction.
+ *
+ * Decouples internal code from the transport library's (Ktor) frame types.
+ * Only [RealTransport] converts between [TransportFrame] and Ktor frames.
+ *
+ * Internal visibility — not part of the public API.
+ */
+internal sealed class TransportFrame {
+    /** UTF-8 text payload. */
+    data class Text(
+        val data: String,
+    ) : TransportFrame()
+
+    /** Raw binary payload. */
+    class Binary(
+        val data: ByteArray,
+    ) : TransportFrame() {
+        override fun equals(other: Any?): Boolean = this === other || (other is Binary && data.contentEquals(other.data))
+
+        override fun hashCode(): Int = data.contentHashCode()
+
+        override fun toString(): String = "TransportFrame.Binary(${data.size} bytes)"
+    }
+
+    /** Ping frame. */
+    class Ping(
+        val data: ByteArray,
+    ) : TransportFrame() {
+        override fun equals(other: Any?): Boolean = this === other || (other is Ping && data.contentEquals(other.data))
+
+        override fun hashCode(): Int = data.contentHashCode()
+
+        override fun toString(): String = "TransportFrame.Ping(${data.size} bytes)"
+    }
+
+    /** Pong frame (response to Ping). */
+    class Pong(
+        val data: ByteArray,
+    ) : TransportFrame() {
+        override fun equals(other: Any?): Boolean = this === other || (other is Pong && data.contentEquals(other.data))
+
+        override fun hashCode(): Int = data.contentHashCode()
+
+        override fun toString(): String = "TransportFrame.Pong(${data.size} bytes)"
+    }
+
+    /** Close frame. */
+    data class Close(
+        val code: Short,
+        val reason: String,
+    ) : TransportFrame()
+}
+
+/**
+ * Library-owned WebSocket close reason.
+ *
+ * Used as parameter to [Transport.close] — conceptually distinct from
+ * [TransportFrame.Close] which represents a received close frame.
+ *
+ * Internal visibility — not part of the public API.
+ */
+internal data class TransportCloseReason(
+    val code: Short,
+    val reason: String,
+) {
+    companion object {
+        /** Normal closure (1000). */
+        val NORMAL = TransportCloseReason(1000, "")
+
+        /** Going away (1001) — used for reconnect and pong timeout. */
+        val GOING_AWAY = TransportCloseReason(1001, "")
+    }
+}

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -8,6 +8,8 @@ import io.ktor.http.headers
 import io.ktor.websocket.CloseReason
 import io.ktor.websocket.DefaultWebSocketSession
 import io.ktor.websocket.close
+import io.ktor.websocket.readBytes
+import io.ktor.websocket.readText
 import io.ktor.websocket.send
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -19,6 +21,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -135,7 +139,7 @@ class WspulseClient private constructor(
                                 dialHeaders.forEach { (k, v) -> append(k, v) }
                             }
                         }
-                    RealTransport(session)
+                    RealTransport(session, CoroutineScope(session.coroutineContext))
                 }
 
             return connectInternal(normalizedUrl, config, dialer) { httpClient.close() }
@@ -235,7 +239,7 @@ class WspulseClient private constructor(
 
         // Send WebSocket close frame (best-effort).
         try {
-            transport?.close(CloseReason(CloseReason.Codes.NORMAL, ""))
+            transport?.close(TransportCloseReason.NORMAL)
         } catch (_: Exception) {
             // Already closed — ignore.
         }
@@ -272,7 +276,7 @@ class WspulseClient private constructor(
         if (oldTransport != null) {
             scope.launch {
                 try {
-                    oldTransport.close(CloseReason(CloseReason.Codes.GOING_AWAY, "reconnecting"))
+                    oldTransport.close(TransportCloseReason.GOING_AWAY)
                 } catch (_: Exception) {
                     // already closed
                 }
@@ -309,9 +313,9 @@ class WspulseClient private constructor(
 
                 val data: ByteArray =
                     when (wsFrame) {
-                        is WsFrame.Text -> wsFrame.data
-                        is WsFrame.Binary -> wsFrame.data
-                        is WsFrame.Pong -> {
+                        is TransportFrame.Text -> wsFrame.data.toByteArray(Charsets.UTF_8)
+                        is TransportFrame.Binary -> wsFrame.data
+                        is TransportFrame.Pong -> {
                             resetPongDeadline(ws)
                             continue
                         }
@@ -326,7 +330,7 @@ class WspulseClient private constructor(
                         config.maxMessageSize,
                     )
                     try {
-                        ws.close(CloseReason(CloseReason.Codes.TOO_BIG, "message too large"))
+                        ws.close(TransportCloseReason(1009, "message too large"))
                     } catch (_: Exception) {
                         // already closing
                     }
@@ -373,8 +377,8 @@ class WspulseClient private constructor(
 
                 val wsFrame =
                     when (config.codec.frameType) {
-                        FrameType.TEXT -> WsFrame.Text(String(data, Charsets.UTF_8))
-                        FrameType.BINARY -> WsFrame.Binary(true, data)
+                        FrameType.TEXT -> TransportFrame.Text(String(data, Charsets.UTF_8))
+                        FrameType.BINARY -> TransportFrame.Binary(data)
                     }
 
                 try {
@@ -386,7 +390,7 @@ class WspulseClient private constructor(
                     logger.warn("wspulse/client: write failed", e)
                     dropped.complete(e)
                     try {
-                        ws.close(CloseReason(CloseReason.Codes.GOING_AWAY, "write error"))
+                        ws.close(TransportCloseReason.GOING_AWAY)
                     } catch (_: Exception) {
                         // already closing
                     }
@@ -415,7 +419,7 @@ class WspulseClient private constructor(
 
         // Send initial ping and start pong deadline.
         try {
-            ws.send(WsFrame.Ping(ByteArray(0)))
+            ws.send(TransportFrame.Ping(ByteArray(0)))
             resetPongDeadline(ws)
         } catch (e: Exception) {
             dropped.complete(e)
@@ -425,7 +429,7 @@ class WspulseClient private constructor(
         try {
             while (scope.isActive) {
                 delay(pingPeriod)
-                ws.send(WsFrame.Ping(ByteArray(0)))
+                ws.send(TransportFrame.Ping(ByteArray(0)))
             }
         } catch (_: CancellationException) {
             // Normal shutdown.
@@ -448,7 +452,7 @@ class WspulseClient private constructor(
                 delay(config.heartbeat.pongWait)
                 logger.warn("wspulse/client: pong timeout, closing connection")
                 try {
-                    ws.close(CloseReason(CloseReason.Codes.GOING_AWAY, "pong timeout"))
+                    ws.close(TransportCloseReason.GOING_AWAY)
                 } catch (_: Exception) {
                     // already closing
                 }
@@ -526,7 +530,7 @@ class WspulseClient private constructor(
                 // Check if close() was called during dial.
                 if (closed.get()) {
                     try {
-                        newTransport.close(CloseReason(CloseReason.Codes.NORMAL, ""))
+                        newTransport.close(TransportCloseReason.NORMAL)
                     } catch (_: Exception) {
                         // ignore
                     }
@@ -609,16 +613,62 @@ class WspulseClient private constructor(
 /**
  * [Transport] backed by a Ktor [DefaultWebSocketSession].
  *
+ * This is the only class that converts between library-owned [TransportFrame]
+ * and Ktor's frame types. All Ktor WebSocket frame imports are confined here
+ * and in the production dialer lambda above.
+ *
  * Internal visibility — not part of the public API.
  */
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 internal class RealTransport(
     private val session: DefaultWebSocketSession,
+    scope: CoroutineScope,
 ) : Transport {
-    override val incoming get() = session.incoming
+    override val incoming: ReceiveChannel<TransportFrame> =
+        scope.produce {
+            for (frame in session.incoming) {
+                val mapped =
+                    when (frame) {
+                        is WsFrame.Text -> TransportFrame.Text(frame.readText())
+                        is WsFrame.Binary -> TransportFrame.Binary(frame.readBytes())
+                        is WsFrame.Ping -> TransportFrame.Ping(frame.data)
+                        is WsFrame.Pong -> TransportFrame.Pong(frame.data)
+                        is WsFrame.Close -> {
+                            val reason = frame.readBytes()
+                            val code =
+                                if (reason.size >= 2) {
+                                    (
+                                        (reason[0].toInt() and 0xFF shl 8) or
+                                            (reason[1].toInt() and 0xFF)
+                                    ).toShort()
+                                } else {
+                                    1006.toShort()
+                                }
+                            val msg =
+                                if (reason.size > 2) {
+                                    String(reason, 2, reason.size - 2, Charsets.UTF_8)
+                                } else {
+                                    ""
+                                }
+                            TransportFrame.Close(code, msg)
+                        }
+                    }
+                send(mapped)
+            }
+        }
 
-    override suspend fun send(frame: WsFrame) = session.send(frame)
+    override suspend fun send(frame: TransportFrame) {
+        when (frame) {
+            is TransportFrame.Text -> session.send(frame.data)
+            is TransportFrame.Binary -> session.send(WsFrame.Binary(true, frame.data))
+            is TransportFrame.Ping -> session.send(WsFrame.Ping(frame.data))
+            is TransportFrame.Pong -> session.send(WsFrame.Pong(frame.data))
+            is TransportFrame.Close ->
+                session.close(CloseReason(frame.code, frame.reason))
+        }
+    }
 
-    override suspend fun close(reason: CloseReason) = session.close(reason)
+    override suspend fun close(reason: TransportCloseReason) = session.close(CloseReason(reason.code, reason.reason))
 }
 
 /**

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -276,7 +276,7 @@ class WspulseClient private constructor(
         if (oldTransport != null) {
             scope.launch {
                 try {
-                    oldTransport.close(TransportCloseReason.GOING_AWAY)
+                    oldTransport.close(TransportCloseReason.RECONNECTING)
                 } catch (_: Exception) {
                     // already closed
                 }
@@ -330,7 +330,7 @@ class WspulseClient private constructor(
                         config.maxMessageSize,
                     )
                     try {
-                        ws.close(TransportCloseReason(1009, "message too large"))
+                        ws.close(TransportCloseReason.MESSAGE_TOO_LARGE)
                     } catch (_: Exception) {
                         // already closing
                     }
@@ -390,7 +390,7 @@ class WspulseClient private constructor(
                     logger.warn("wspulse/client: write failed", e)
                     dropped.complete(e)
                     try {
-                        ws.close(TransportCloseReason.GOING_AWAY)
+                        ws.close(TransportCloseReason.WRITE_ERROR)
                     } catch (_: Exception) {
                         // already closing
                     }
@@ -452,7 +452,7 @@ class WspulseClient private constructor(
                 delay(config.heartbeat.pongWait)
                 logger.warn("wspulse/client: pong timeout, closing connection")
                 try {
-                    ws.close(TransportCloseReason.GOING_AWAY)
+                    ws.close(TransportCloseReason.PONG_TIMEOUT)
                 } catch (_: Exception) {
                     // already closing
                 }
@@ -642,7 +642,7 @@ internal class RealTransport(
                                             (reason[1].toInt() and 0xFF)
                                     ).toShort()
                                 } else {
-                                    1006.toShort()
+                                    1005.toShort()
                                 }
                             val msg =
                                 if (reason.size > 2) {

--- a/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
@@ -4,6 +4,7 @@ import com.wspulse.client.Client
 import com.wspulse.client.ClientConfig
 import com.wspulse.client.Frame
 import com.wspulse.client.HeartbeatConfig
+import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
 import kotlinx.coroutines.Dispatchers
@@ -76,7 +77,7 @@ class BasicTest {
             client.send(Frame(event = "msg", payload = mapOf("text" to "hello")))
 
             // Wait for writeLoop to pick up the frame.
-            waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Text } }
+            waitUntil { transport.sent.any { it is TransportFrame.Text } }
 
             // Simulate server echo.
             transport.injectText("""{"event":"msg","payload":{"text":"hello"}}""")
@@ -131,11 +132,12 @@ class BasicTest {
             client.send(outbound)
 
             // Wait for the write to appear.
-            waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Text } }
+            waitUntil { transport.sent.any { it is TransportFrame.Text } }
 
             // Echo the exact wire bytes back.
-            val textFrame = transport.sent.first { it is io.ktor.websocket.Frame.Text }
-            transport.injectText(String(textFrame.data, Charsets.UTF_8))
+            val textFrame =
+                transport.sent.first { it is TransportFrame.Text } as TransportFrame.Text
+            transport.injectText(textFrame.data)
 
             waitUntil { received.size >= 1 }
 
@@ -193,13 +195,13 @@ class BasicTest {
 
             // Wait for all writes.
             waitUntil {
-                transport.sent.count { it is io.ktor.websocket.Frame.Text } >= count
+                transport.sent.count { it is TransportFrame.Text } >= count
             }
 
             // Echo each in order.
-            val textFrames = transport.sent.filterIsInstance<io.ktor.websocket.Frame.Text>()
+            val textFrames = transport.sent.filterIsInstance<TransportFrame.Text>()
             for (f in textFrames) {
-                transport.injectText(String(f.data, Charsets.UTF_8))
+                transport.injectText(f.data)
             }
 
             waitUntil { received.size >= count }
@@ -234,7 +236,7 @@ class BasicTest {
 
     private suspend fun waitForPing(transport: MockTransport) {
         waitUntil {
-            transport.sent.any { it is io.ktor.websocket.Frame.Ping }
+            transport.sent.any { it is TransportFrame.Ping }
         }
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
@@ -4,6 +4,7 @@ import com.wspulse.client.AutoReconnectConfig
 import com.wspulse.client.Client
 import com.wspulse.client.ClientConfig
 import com.wspulse.client.HeartbeatConfig
+import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
 import kotlinx.coroutines.Dispatchers
@@ -283,7 +284,7 @@ class CallbackTest {
 
     private suspend fun waitForPing(transport: MockTransport) {
         waitUntil {
-            transport.sent.any { it is io.ktor.websocket.Frame.Ping }
+            transport.sent.any { it is TransportFrame.Ping }
         }
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
@@ -5,6 +5,7 @@ import com.wspulse.client.ClientConfig
 import com.wspulse.client.ConnectionClosedException
 import com.wspulse.client.Frame
 import com.wspulse.client.HeartbeatConfig
+import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -166,7 +167,7 @@ class LifecycleTest {
 
     private suspend fun waitForPing(transport: MockTransport) {
         waitUntil {
-            transport.sent.any { it is io.ktor.websocket.Frame.Ping }
+            transport.sent.any { it is TransportFrame.Ping }
         }
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
@@ -5,6 +5,7 @@ import com.wspulse.client.ClientConfig
 import com.wspulse.client.ConnectionLostException
 import com.wspulse.client.Frame
 import com.wspulse.client.HeartbeatConfig
+import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
 import kotlinx.coroutines.Dispatchers
@@ -85,13 +86,13 @@ class MiscTest {
 
             // Wait for all writes to appear in the transport.
             waitUntil(timeoutMs = 10_000) {
-                transport.sent.count { it is io.ktor.websocket.Frame.Text } >= total
+                transport.sent.count { it is TransportFrame.Text } >= total
             }
 
             // Inject echoes.
-            val textFrames = transport.sent.filterIsInstance<io.ktor.websocket.Frame.Text>()
+            val textFrames = transport.sent.filterIsInstance<TransportFrame.Text>()
             for (f in textFrames) {
-                transport.injectText(String(f.data, Charsets.UTF_8))
+                transport.injectText(f.data)
             }
 
             waitUntil(timeoutMs = 10_000) { received.size >= total }
@@ -163,7 +164,7 @@ class MiscTest {
 
     private suspend fun waitForPing(transport: MockTransport) {
         waitUntil {
-            transport.sent.any { it is io.ktor.websocket.Frame.Ping }
+            transport.sent.any { it is TransportFrame.Ping }
         }
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/MockTransport.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MockTransport.kt
@@ -2,13 +2,13 @@ package com.wspulse.client.component
 
 import com.wspulse.client.Dialer
 import com.wspulse.client.Transport
-import io.ktor.websocket.CloseReason
+import com.wspulse.client.TransportCloseReason
+import com.wspulse.client.TransportFrame
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
-import io.ktor.websocket.Frame as WsFrame
 
 /**
  * In-memory [Transport] for component tests.
@@ -17,23 +17,23 @@ import io.ktor.websocket.Frame as WsFrame
  * Outgoing frames sent by the client are captured in [sent].
  */
 internal class MockTransport : Transport {
-    private val incomingChannel = Channel<WsFrame>(Channel.UNLIMITED)
+    private val incomingChannel = Channel<TransportFrame>(Channel.UNLIMITED)
     private val closedFlag = AtomicBoolean(false)
 
     /** All frames sent by the client through this transport. */
-    val sent = CopyOnWriteArrayList<WsFrame>()
+    val sent = CopyOnWriteArrayList<TransportFrame>()
 
     /** Whether [close] has been called. */
     val isClosed: Boolean get() = closedFlag.get()
 
-    override val incoming: ReceiveChannel<WsFrame> get() = incomingChannel
+    override val incoming: ReceiveChannel<TransportFrame> get() = incomingChannel
 
-    override suspend fun send(frame: WsFrame) {
+    override suspend fun send(frame: TransportFrame) {
         if (closedFlag.get()) throw IllegalStateException("transport closed")
         sent.add(frame)
     }
 
-    override suspend fun close(reason: CloseReason) {
+    override suspend fun close(reason: TransportCloseReason) {
         if (closedFlag.compareAndSet(false, true)) {
             incomingChannel.close()
         }
@@ -43,12 +43,12 @@ internal class MockTransport : Transport {
 
     /** Inject a text frame (simulates server sending a message). */
     fun injectText(data: String) {
-        incomingChannel.trySend(WsFrame.Text(data)).getOrThrow()
+        incomingChannel.trySend(TransportFrame.Text(data)).getOrThrow()
     }
 
     /** Inject a pong frame (simulates server responding to ping). */
     fun injectPong() {
-        incomingChannel.trySend(WsFrame.Pong(ByteArray(0))).getOrThrow()
+        incomingChannel.trySend(TransportFrame.Pong(ByteArray(0))).getOrThrow()
     }
 
     /** Close the incoming channel (simulates transport drop). */
@@ -94,7 +94,7 @@ internal class PongResponder(
         val size = frames.size
         for (i in lastSeen.get() until size) {
             val frame = frames[i]
-            if (frame is WsFrame.Ping && active.get()) {
+            if (frame is TransportFrame.Ping && active.get()) {
                 transport.injectPong()
             }
         }

--- a/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
@@ -8,6 +8,7 @@ import com.wspulse.client.Frame
 import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.RetriesExhaustedException
 import com.wspulse.client.Transport
+import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
 import kotlinx.coroutines.CompletableDeferred
@@ -83,7 +84,7 @@ class ReconnectTest {
 
             // Send a frame before drop.
             client.send(Frame(event = "before", payload = "drop"))
-            waitUntil { transport1.sent.any { it is io.ktor.websocket.Frame.Text } }
+            waitUntil { transport1.sent.any { it is TransportFrame.Text } }
             transport1.injectText("""{"event":"before","payload":"drop"}""")
             waitUntil { received.any { it.event == "before" } }
 
@@ -112,7 +113,7 @@ class ReconnectTest {
 
             // Send after reconnect.
             client.send(Frame(event = "after", payload = "reconnect"))
-            waitUntil { transport2.sent.any { it is io.ktor.websocket.Frame.Text } }
+            waitUntil { transport2.sent.any { it is TransportFrame.Text } }
             transport2.injectText("""{"event":"after","payload":"reconnect"}""")
             waitUntil { received.any { it.event == "after" } }
         }
@@ -266,7 +267,7 @@ class ReconnectTest {
 
     private suspend fun waitForPing(transport: MockTransport) {
         waitUntil {
-            transport.sent.any { it is io.ktor.websocket.Frame.Ping }
+            transport.sent.any { it is TransportFrame.Ping }
         }
     }
 }


### PR DESCRIPTION
## Summary

Replace Ktor `Frame` and `CloseReason` types in the internal `Transport` interface with library-owned `TransportFrame` (sealed class) and `TransportCloseReason`, so Ktor is fully encapsulated inside `RealTransport`. Closes #17.

## Changes

- New `TransportFrame.kt`: sealed class with `Text`, `Binary`, `Ping`, `Pong`, `Close` variants + `TransportCloseReason` data class
- `Transport.kt`: `incoming`, `send()`, `close()` now use `TransportFrame`/`TransportCloseReason` — zero Ktor imports
- `WspulseClient.kt` (`RealTransport`): maps between Ktor frames and `TransportFrame` at the boundary via `produce` (incoming) and `when` (send). All Ktor WebSocket frame imports confined here + dialer lambda
- `WspulseClient.kt` (internal logic): all `WsFrame.Text/Binary/Ping/Pong` references replaced with `TransportFrame` equivalents; all `CloseReason` usages replaced with `TransportCloseReason`
- `MockTransport.kt`: fully Ktor-free — uses `TransportFrame` for `sent` list, incoming channel, injection helpers
- All 5 component test files: assertions updated from `is WsFrame.Text` to `is TransportFrame.Text` etc.
- `CHANGELOG.md`: entry under [Unreleased]

## Checklist

### Required

- [x] `make check` passes (lint → test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] `send()` and `close()` remain safe for concurrent use from multiple coroutines