### PR TITLE
feat: inject dispatcher/random for deterministic tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - `random` parameter on internal `backoff()` — injects a `Random` instance, enabling deterministic jitter in tests.
 - Component tests: all 5 test classes now inject `UnconfinedTestDispatcher(testScheduler)` so heartbeat timers use virtual time, replacing `withContext(Dispatchers.Default)` busy-wait loops with `testScheduler.advanceTimeBy()` for reconnect and pong-timeout scenarios.
 - `waitUntil` helpers gain a synchronous fast-path (`if (condition()) return`) that avoids releasing the test coroutine to `workRunner` when the condition is already satisfied.
-
 - `connect()` auto-converts `http://` to `ws://` and `https://` to `wss://` (case-insensitive per RFC 3986). Unsupported or missing schemes throw `IllegalArgumentException`.
 - `sendBufferSize` config option — configurable outbound channel capacity [1, 4096], default 256
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@
 - Component tests: all 5 test classes now inject `UnconfinedTestDispatcher(testScheduler)` so heartbeat timers use virtual time, replacing `withContext(Dispatchers.Default)` busy-wait loops with `testScheduler.advanceTimeBy()` for reconnect and pong-timeout scenarios.
 - `waitUntil` helpers gain a synchronous fast-path (`if (condition()) return`) that avoids releasing the test coroutine to `workRunner` when the condition is already satisfied.
 
-### Added
-
 - `connect()` auto-converts `http://` to `ws://` and `https://` to `wss://` (case-insensitive per RFC 3986). Unsupported or missing schemes throw `IllegalArgumentException`.
 - `sendBufferSize` config option — configurable outbound channel capacity [1, 4096], default 256
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- `dispatcher` parameter on internal `connectInternal()` — injects a `CoroutineDispatcher` for the client's coroutine scope, enabling virtual-time testing with `UnconfinedTestDispatcher`.
+- `random` parameter on internal `backoff()` — injects a `Random` instance, enabling deterministic jitter in tests.
+- Component tests: all 5 test classes now inject `UnconfinedTestDispatcher(testScheduler)` so heartbeat timers use virtual time, replacing `withContext(Dispatchers.Default)` busy-wait loops with `testScheduler.advanceTimeBy()` for reconnect and pong-timeout scenarios.
+- `waitUntil` helpers gain a synchronous fast-path (`if (condition()) return`) that avoids releasing the test coroutine to `workRunner` when the condition is already satisfied.
+
+### Added
+
 - `connect()` auto-converts `http://` to `ws://` and `https://` to `wss://` (case-insensitive per RFC 3986). Unsupported or missing schemes throw `IllegalArgumentException`.
 - `sendBufferSize` config option — configurable outbound channel capacity [1, 4096], default 256
 

--- a/src/main/kotlin/com/wspulse/client/Backoff.kt
+++ b/src/main/kotlin/com/wspulse/client/Backoff.kt
@@ -16,6 +16,7 @@ import kotlin.time.Duration.Companion.nanoseconds
  * @param attempt 0-based reconnection attempt number.
  * @param base base delay duration.
  * @param max upper bound for the computed delay.
+ * @param random random source for jitter (defaults to [Random.Default]).
  * @return jittered backoff duration.
  */
 internal fun backoff(

--- a/src/main/kotlin/com/wspulse/client/Backoff.kt
+++ b/src/main/kotlin/com/wspulse/client/Backoff.kt
@@ -8,22 +8,21 @@ import kotlin.time.Duration.Companion.nanoseconds
 /**
  * Computes an exponential backoff delay with equal jitter.
  *
- * The result is uniformly distributed in `[delay * 0.5, delay * 1.0]` where
- * `delay = min(base * 2^attempt, max)`. The shift is capped at 62 bits to
- * prevent overflow.
+ * The result is uniformly distributed in `[delay * 0.5, delay * 1.0]` where `delay = min(base *
+ * 2^attempt, max)`. The shift is capped at 62 bits to prevent overflow.
  *
- * This function must produce the same distribution as all other
- * `wspulse/client-*` libraries.
+ * This function must produce the same distribution as all other `wspulse/client-*` libraries.
  *
  * @param attempt 0-based reconnection attempt number.
- * @param base    base delay duration.
- * @param max     upper bound for the computed delay.
+ * @param base base delay duration.
+ * @param max upper bound for the computed delay.
  * @return jittered backoff duration.
  */
 internal fun backoff(
-    attempt: Int,
-    base: Duration,
-    max: Duration,
+        attempt: Int,
+        base: Duration,
+        max: Duration,
+        random: Random = Random,
 ): Duration {
     val shift = min(attempt, 62)
     val baseNs = base.inWholeNanoseconds
@@ -31,12 +30,12 @@ internal fun backoff(
     val multiplier = 1L shl shift
     // Detect overflow: if base > max / multiplier, the product would exceed max (or overflow).
     val delayNs =
-        if (multiplier != 0L && baseNs > maxNs / multiplier) {
-            maxNs
-        } else {
-            min(baseNs * multiplier, maxNs)
-        }
+            if (multiplier != 0L && baseNs > maxNs / multiplier) {
+                maxNs
+            } else {
+                min(baseNs * multiplier, maxNs)
+            }
     val halfNs = delayNs / 2
-    val jitterNs = if (halfNs > 0) Random.nextLong(halfNs + 1) else 0L
+    val jitterNs = if (halfNs > 0) random.nextLong(halfNs + 1) else 0L
     return (halfNs + jitterNs).nanoseconds
 }

--- a/src/main/kotlin/com/wspulse/client/Backoff.kt
+++ b/src/main/kotlin/com/wspulse/client/Backoff.kt
@@ -19,10 +19,10 @@ import kotlin.time.Duration.Companion.nanoseconds
  * @return jittered backoff duration.
  */
 internal fun backoff(
-        attempt: Int,
-        base: Duration,
-        max: Duration,
-        random: Random = Random,
+    attempt: Int,
+    base: Duration,
+    max: Duration,
+    random: Random = Random,
 ): Duration {
     val shift = min(attempt, 62)
     val baseNs = base.inWholeNanoseconds
@@ -30,11 +30,11 @@ internal fun backoff(
     val multiplier = 1L shl shift
     // Detect overflow: if base > max / multiplier, the product would exceed max (or overflow).
     val delayNs =
-            if (multiplier != 0L && baseNs > maxNs / multiplier) {
-                maxNs
-            } else {
-                min(baseNs * multiplier, maxNs)
-            }
+        if (multiplier != 0L && baseNs > maxNs / multiplier) {
+            maxNs
+        } else {
+            min(baseNs * multiplier, maxNs)
+        }
     val halfNs = delayNs / 2
     val jitterNs = if (halfNs > 0) random.nextLong(halfNs + 1) else 0L
     return (halfNs + jitterNs).nanoseconds

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -100,7 +100,7 @@ class WspulseClient private constructor(
     private val dialer: Dialer,
     private val onShutdown: () -> Unit,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val random: Random = Random,
+    private val random: Random = Random.Default,
 ) : Client {
     companion object {
         private val logger = LoggerFactory.getLogger(WspulseClient::class.java)
@@ -162,7 +162,7 @@ class WspulseClient private constructor(
             dialer: Dialer,
             onShutdown: () -> Unit = {},
             dispatcher: CoroutineDispatcher = Dispatchers.IO,
-            random: Random = Random,
+            random: Random = Random.Default,
         ): Client {
             val client = WspulseClient(url, config, dialer, onShutdown, dispatcher, random)
 

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -7,12 +7,8 @@ import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.http.headers
 import io.ktor.websocket.CloseReason
 import io.ktor.websocket.DefaultWebSocketSession
-import io.ktor.websocket.Frame as WsFrame
 import io.ktor.websocket.close
 import io.ktor.websocket.send
-import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
@@ -29,6 +25,10 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import io.ktor.websocket.Frame as WsFrame
 
 /**
  * Public interface for the wspulse WebSocket client.
@@ -88,229 +88,230 @@ private const val MAX_RETRIES_LIMIT = 32
  * - CLOSED: permanently disconnected, all resources released.
  */
 class WspulseClient
-private constructor(
+    private constructor(
         private val url: String,
         private val config: ClientConfig,
         private val dialer: Dialer,
         private val onShutdown: () -> Unit,
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : Client {
-    companion object {
-        private val logger = LoggerFactory.getLogger(WspulseClient::class.java)
+    ) : Client {
+        companion object {
+            private val logger = LoggerFactory.getLogger(WspulseClient::class.java)
 
-        /**
-         * Connect to a wspulse WebSocket server.
-         *
-         * The initial dial is always fatal: if the handshake fails, the exception is propagated to
-         * the caller regardless of whether [ClientConfig.autoReconnect] is configured. No callbacks
-         * fire and no [Client] is returned to the caller. Auto-reconnect only activates after a
-         * successful initial connection subsequently drops.
-         *
-         * @param url WebSocket or HTTP URL (e.g. `wss://host/ws`).
-         * ```
-         *             `http://` and `https://` schemes are auto-converted
-         *             to `ws://` and `wss://` respectively.
-         * @param init
-         * ```
-         * DSL block to configure the client.
-         * @return A [Client] whose initial WebSocket handshake has completed
-         * ```
-         *         successfully. The underlying transport is connected on a
-         *         best-effort basis and may transition to reconnecting or closed
-         *         state according to the configured lifecycle.
-         * ```
-         */
-        suspend fun connect(
+            /**
+             * Connect to a wspulse WebSocket server.
+             *
+             * The initial dial is always fatal: if the handshake fails, the exception is propagated to
+             * the caller regardless of whether [ClientConfig.autoReconnect] is configured. No callbacks
+             * fire and no [Client] is returned to the caller. Auto-reconnect only activates after a
+             * successful initial connection subsequently drops.
+             *
+             * @param url WebSocket or HTTP URL (e.g. `wss://host/ws`).
+             * ```
+             *             `http://` and `https://` schemes are auto-converted
+             *             to `ws://` and `wss://` respectively.
+             * @param init
+             * ```
+             * DSL block to configure the client.
+             * @return A [Client] whose initial WebSocket handshake has completed
+             * ```
+             *         successfully. The underlying transport is connected on a
+             *         best-effort basis and may transition to reconnecting or closed
+             *         state according to the configured lifecycle.
+             * ```
+             */
+            suspend fun connect(
                 url: String,
                 init: ClientConfig.() -> Unit = {},
-        ): Client {
-            val normalizedUrl = normalizeScheme(url)
-            val config = ClientConfig().apply(init)
-            validateConfig(config)
-            val httpClient = HttpClient(CIO) { install(WebSockets) }
+            ): Client {
+                val normalizedUrl = normalizeScheme(url)
+                val config = ClientConfig().apply(init)
+                validateConfig(config)
+                val httpClient = HttpClient(CIO) { install(WebSockets) }
 
-            val dialer = Dialer { dialUrl, dialHeaders ->
-                val session =
-                        httpClient.webSocketSession(dialUrl) {
-                            headers { dialHeaders.forEach { (k, v) -> append(k, v) } }
-                        }
-                RealTransport(session)
-            }
+                val dialer =
+                    Dialer { dialUrl, dialHeaders ->
+                        val session =
+                            httpClient.webSocketSession(dialUrl) {
+                                headers { dialHeaders.forEach { (k, v) -> append(k, v) } }
+                            }
+                        RealTransport(session)
+                    }
 
-            return connectInternal(
+                return connectInternal(
                     normalizedUrl,
                     config,
                     dialer,
-                    onShutdown = { httpClient.close() }
-            )
-        }
+                    onShutdown = { httpClient.close() },
+                )
+            }
 
-        /**
-         * Internal connect for testing — accepts a custom [Dialer].
-         *
-         * Not part of the public API. Callers must validate config and normalize the URL before
-         * calling.
-         */
-        @JvmSynthetic
-        internal suspend fun connectInternal(
+            /**
+             * Internal connect for testing — accepts a custom [Dialer].
+             *
+             * Not part of the public API. Callers must validate config and normalize the URL before
+             * calling.
+             */
+            @JvmSynthetic
+            internal suspend fun connectInternal(
                 url: String,
                 config: ClientConfig,
                 dialer: Dialer,
                 onShutdown: () -> Unit = {},
                 dispatcher: CoroutineDispatcher = Dispatchers.IO,
-        ): Client {
-            val client = WspulseClient(url, config, dialer, onShutdown, dispatcher)
+            ): Client {
+                val client = WspulseClient(url, config, dialer, onShutdown, dispatcher)
 
-            try {
-                val transport = client.dialOnce()
-                val dropped = client.startConnection(transport)
-                // Monitor for transport drop -> reconnect or permanent disconnect.
-                client.scope.launch {
-                    val cause: Exception?
-                    try {
-                        cause = dropped.await()
-                    } catch (_: CancellationException) {
-                        return@launch
-                    }
-                    client.handleTransportDrop(cause)
-                }
-            } catch (e: Exception) {
-                // Release resources before propagating.
-                client.scope.coroutineContext[Job]?.cancel()
-                client.onShutdown()
-                throw e
-            }
-
-            return client
-        }
-    }
-
-    /** Scope that owns all internal coroutines. */
-    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
-
-    /** Bounded send channel. [send] uses [Channel.trySend] (non-blocking). */
-    private val sendChannel = Channel<ByteArray>(config.sendBufferSize)
-
-    /** Completes on permanent disconnect. */
-    private val _done = CompletableDeferred<Unit>()
-    override val done: Deferred<Unit>
-        get() = _done
-
-    /** Guards [shutdown] to fire exactly once. */
-    private val shutdownOnce = AtomicBoolean(false)
-
-    /** Whether [close] has been called. */
-    private val closed = AtomicBoolean(false)
-
-    /** Guards [handleTransportDrop] to prevent concurrent reconnect loops. */
-    private val reconnecting = AtomicBoolean(false)
-
-    /**
-     * Job for the current connection's coroutines (readLoop, writeLoop, pingLoop). Cancelled and
-     * replaced on each reconnect so old loops stop before new ones start.
-     */
-    private var connectionJob: Job? = null
-
-    /** Current transport. Guarded by [connectionJob] lifecycle. */
-    @Volatile private var transport: Transport? = null
-
-    // ── public API ──────────────────────────────────────────────────────────
-
-    override fun send(frame: Frame) {
-        if (closed.get() || _done.isCompleted) throw ConnectionClosedException()
-
-        val data = config.codec.encode(frame)
-
-        val result = sendChannel.trySend(data)
-        if (result.isFailure) {
-            if (_done.isCompleted) throw ConnectionClosedException()
-            throw SendBufferFullException()
-        }
-    }
-
-    override suspend fun close() {
-        if (!closed.compareAndSet(false, true)) {
-            // Already closing/closed — just wait for completion.
-            _done.await()
-            return
-        }
-
-        logger.info("wspulse/client: closing url={}", url)
-
-        // Send WebSocket close frame (best-effort).
-        try {
-            transport?.close(CloseReason(CloseReason.Codes.NORMAL, ""))
-        } catch (_: Exception) {
-            // Already closed — ignore.
-        }
-
-        // Cancel the scope and wait for all child coroutines to finish.
-        scope.coroutineContext[Job]?.cancelAndJoin()
-
-        // Transition to CLOSED.
-        shutdown(null)
-    }
-
-    // ── internal: connection lifecycle ───────────────────────────────────────
-
-    /**
-     * Dial the WebSocket server once.
-     *
-     * @throws Exception on connection failure.
-     */
-    private suspend fun dialOnce(): Transport = dialer.dial(url, config.dialHeaders)
-
-    /**
-     * Start readLoop, writeLoop, and pingLoop for a new transport.
-     *
-     * Previous connection coroutines (if any) are cancelled first.
-     *
-     * @return the [CompletableDeferred] that completes when the transport drops.
-     */
-    private fun startConnection(ws: Transport): CompletableDeferred<Exception?> {
-        connectionJob?.cancel()
-        val oldTransport = transport
-        transport = ws
-
-        // Best-effort close the previous transport.
-        if (oldTransport != null) {
-            scope.launch {
                 try {
-                    oldTransport.close(CloseReason(CloseReason.Codes.GOING_AWAY, "reconnecting"))
-                } catch (_: Exception) {
-                    // already closed
+                    val transport = client.dialOnce()
+                    val dropped = client.startConnection(transport)
+                    // Monitor for transport drop -> reconnect or permanent disconnect.
+                    client.scope.launch {
+                        val cause: Exception?
+                        try {
+                            cause = dropped.await()
+                        } catch (_: CancellationException) {
+                            return@launch
+                        }
+                        client.handleTransportDrop(cause)
+                    }
+                } catch (e: Exception) {
+                    // Release resources before propagating.
+                    client.scope.coroutineContext[Job]?.cancel()
+                    client.onShutdown()
+                    throw e
                 }
+
+                return client
             }
         }
 
-        val job = Job(scope.coroutineContext[Job])
-        connectionJob = job
-        val connScope = CoroutineScope(scope.coroutineContext + job)
+        /** Scope that owns all internal coroutines. */
+        private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
-        val dropped = CompletableDeferred<Exception?>()
+        /** Bounded send channel. [send] uses [Channel.trySend] (non-blocking). */
+        private val sendChannel = Channel<ByteArray>(config.sendBufferSize)
 
-        connScope.launch { readLoop(ws, dropped) }
-        connScope.launch { writeLoop(ws, dropped) }
-        connScope.launch { pingLoop(ws, dropped) }
+        /** Completes on permanent disconnect. */
+        private val _done = CompletableDeferred<Unit>()
+        override val done: Deferred<Unit>
+            get() = _done
 
-        return dropped
-    }
+        /** Guards [shutdown] to fire exactly once. */
+        private val shutdownOnce = AtomicBoolean(false)
 
-    /**
-     * Read incoming WebSocket frames, decode, and dispatch to onMessage.
-     *
-     * Completes [dropped] when the transport's incoming channel closes (transport drop).
-     */
-    private suspend fun readLoop(
+        /** Whether [close] has been called. */
+        private val closed = AtomicBoolean(false)
+
+        /** Guards [handleTransportDrop] to prevent concurrent reconnect loops. */
+        private val reconnecting = AtomicBoolean(false)
+
+        /**
+         * Job for the current connection's coroutines (readLoop, writeLoop, pingLoop). Cancelled and
+         * replaced on each reconnect so old loops stop before new ones start.
+         */
+        private var connectionJob: Job? = null
+
+        /** Current transport. Guarded by [connectionJob] lifecycle. */
+        @Volatile private var transport: Transport? = null
+
+        // ── public API ──────────────────────────────────────────────────────────
+
+        override fun send(frame: Frame) {
+            if (closed.get() || _done.isCompleted) throw ConnectionClosedException()
+
+            val data = config.codec.encode(frame)
+
+            val result = sendChannel.trySend(data)
+            if (result.isFailure) {
+                if (_done.isCompleted) throw ConnectionClosedException()
+                throw SendBufferFullException()
+            }
+        }
+
+        override suspend fun close() {
+            if (!closed.compareAndSet(false, true)) {
+                // Already closing/closed — just wait for completion.
+                _done.await()
+                return
+            }
+
+            logger.info("wspulse/client: closing url={}", url)
+
+            // Send WebSocket close frame (best-effort).
+            try {
+                transport?.close(CloseReason(CloseReason.Codes.NORMAL, ""))
+            } catch (_: Exception) {
+                // Already closed — ignore.
+            }
+
+            // Cancel the scope and wait for all child coroutines to finish.
+            scope.coroutineContext[Job]?.cancelAndJoin()
+
+            // Transition to CLOSED.
+            shutdown(null)
+        }
+
+        // ── internal: connection lifecycle ───────────────────────────────────────
+
+        /**
+         * Dial the WebSocket server once.
+         *
+         * @throws Exception on connection failure.
+         */
+        private suspend fun dialOnce(): Transport = dialer.dial(url, config.dialHeaders)
+
+        /**
+         * Start readLoop, writeLoop, and pingLoop for a new transport.
+         *
+         * Previous connection coroutines (if any) are cancelled first.
+         *
+         * @return the [CompletableDeferred] that completes when the transport drops.
+         */
+        private fun startConnection(ws: Transport): CompletableDeferred<Exception?> {
+            connectionJob?.cancel()
+            val oldTransport = transport
+            transport = ws
+
+            // Best-effort close the previous transport.
+            if (oldTransport != null) {
+                scope.launch {
+                    try {
+                        oldTransport.close(CloseReason(CloseReason.Codes.GOING_AWAY, "reconnecting"))
+                    } catch (_: Exception) {
+                        // already closed
+                    }
+                }
+            }
+
+            val job = Job(scope.coroutineContext[Job])
+            connectionJob = job
+            val connScope = CoroutineScope(scope.coroutineContext + job)
+
+            val dropped = CompletableDeferred<Exception?>()
+
+            connScope.launch { readLoop(ws, dropped) }
+            connScope.launch { writeLoop(ws, dropped) }
+            connScope.launch { pingLoop(ws, dropped) }
+
+            return dropped
+        }
+
+        /**
+         * Read incoming WebSocket frames, decode, and dispatch to onMessage.
+         *
+         * Completes [dropped] when the transport's incoming channel closes (transport drop).
+         */
+        private suspend fun readLoop(
             ws: Transport,
             dropped: CompletableDeferred<Exception?>,
-    ) {
-        var readError: Exception? = null
-        try {
-            for (wsFrame in ws.incoming) {
-                if (!scope.isActive) return
+        ) {
+            var readError: Exception? = null
+            try {
+                for (wsFrame in ws.incoming) {
+                    if (!scope.isActive) return
 
-                val data: ByteArray =
+                    val data: ByteArray =
                         when (wsFrame) {
                             is WsFrame.Text -> wsFrame.data
                             is WsFrame.Binary -> wsFrame.data
@@ -321,127 +322,127 @@ private constructor(
                             else -> continue
                         }
 
-                // maxMessageSize enforcement.
-                if (config.maxMessageSize > 0 && data.size.toLong() > config.maxMessageSize) {
-                    logger.warn(
+                    // maxMessageSize enforcement.
+                    if (config.maxMessageSize > 0 && data.size.toLong() > config.maxMessageSize) {
+                        logger.warn(
                             "wspulse/client: message too large ({} > {}), closing",
                             data.size,
                             config.maxMessageSize,
-                    )
-                    try {
-                        ws.close(CloseReason(CloseReason.Codes.TOO_BIG, "message too large"))
-                    } catch (_: Exception) {
-                        // already closing
+                        )
+                        try {
+                            ws.close(CloseReason(CloseReason.Codes.TOO_BIG, "message too large"))
+                        } catch (_: Exception) {
+                            // already closing
+                        }
+                        break
                     }
-                    break
-                }
 
-                val frame: Frame
-                try {
-                    frame = config.codec.decode(data)
-                } catch (e: Exception) {
-                    logger.warn("wspulse/client: decode failed, frame dropped", e)
-                    continue
+                    val frame: Frame
+                    try {
+                        frame = config.codec.decode(data)
+                    } catch (e: Exception) {
+                        logger.warn("wspulse/client: decode failed, frame dropped", e)
+                        continue
+                    }
+                    try {
+                        config.onMessage(frame)
+                    } catch (e: Exception) {
+                        logger.warn("wspulse/client: onMessage callback threw", e)
+                    }
                 }
-                try {
-                    config.onMessage(frame)
-                } catch (e: Exception) {
-                    logger.warn("wspulse/client: onMessage callback threw", e)
-                }
+            } catch (_: ClosedReceiveChannelException) {
+                // Normal: session closed.
+            } catch (_: CancellationException) {
+                throw CancellationException("readLoop cancelled")
+            } catch (e: Exception) {
+                readError = e
+                logger.debug("wspulse/client: readLoop error", e)
+            } finally {
+                dropped.complete(readError)
             }
-        } catch (_: ClosedReceiveChannelException) {
-            // Normal: session closed.
-        } catch (_: CancellationException) {
-            throw CancellationException("readLoop cancelled")
-        } catch (e: Exception) {
-            readError = e
-            logger.debug("wspulse/client: readLoop error", e)
-        } finally {
-            dropped.complete(readError)
         }
-    }
 
-    /**
-     * Consume the send channel and write to the WebSocket.
-     *
-     * Each write is wrapped in [withTimeout] using [ClientConfig.writeWait].
-     */
-    private suspend fun writeLoop(
+        /**
+         * Consume the send channel and write to the WebSocket.
+         *
+         * Each write is wrapped in [withTimeout] using [ClientConfig.writeWait].
+         */
+        private suspend fun writeLoop(
             ws: Transport,
             dropped: CompletableDeferred<Exception?>,
-    ) {
-        try {
-            for (data in sendChannel) {
-                if (!scope.isActive) return
+        ) {
+            try {
+                for (data in sendChannel) {
+                    if (!scope.isActive) return
 
-                val wsFrame =
+                    val wsFrame =
                         when (config.codec.frameType) {
                             FrameType.TEXT -> WsFrame.Text(String(data, Charsets.UTF_8))
                             FrameType.BINARY -> WsFrame.Binary(true, data)
                         }
 
-                try {
-                    withTimeout(config.writeWait) { ws.send(wsFrame) }
-                } catch (e: Exception) {
-                    if (e is CancellationException && !scope.isActive) throw e
-                    logger.warn("wspulse/client: write failed", e)
-                    dropped.complete(e)
                     try {
-                        ws.close(CloseReason(CloseReason.Codes.GOING_AWAY, "write error"))
-                    } catch (_: Exception) {
-                        // already closing
+                        withTimeout(config.writeWait) { ws.send(wsFrame) }
+                    } catch (e: Exception) {
+                        if (e is CancellationException && !scope.isActive) throw e
+                        logger.warn("wspulse/client: write failed", e)
+                        dropped.complete(e)
+                        try {
+                            ws.close(CloseReason(CloseReason.Codes.GOING_AWAY, "write error"))
+                        } catch (_: Exception) {
+                            // already closing
+                        }
+                        return
                     }
-                    return
                 }
+            } catch (_: CancellationException) {
+                // Scope cancelled — normal shutdown.
             }
-        } catch (_: CancellationException) {
-            // Scope cancelled — normal shutdown.
         }
-    }
 
-    // ── internal: heartbeat ─────────────────────────────────────────────────
+        // ── internal: heartbeat ─────────────────────────────────────────────────
 
-    /** Job for the current pong deadline timer. Reset on each Pong received. */
-    @Volatile private var pongDeadlineJob: Job? = null
+        /** Job for the current pong deadline timer. Reset on each Pong received. */
+        @Volatile private var pongDeadlineJob: Job? = null
 
-    /** Send WebSocket Ping frames at [HeartbeatConfig.pingPeriod] intervals. */
-    private suspend fun pingLoop(
+        /** Send WebSocket Ping frames at [HeartbeatConfig.pingPeriod] intervals. */
+        private suspend fun pingLoop(
             ws: Transport,
             dropped: CompletableDeferred<Exception?>,
-    ) {
-        val pingPeriod = config.heartbeat.pingPeriod
+        ) {
+            val pingPeriod = config.heartbeat.pingPeriod
 
-        // Send initial ping and start pong deadline.
-        try {
-            ws.send(WsFrame.Ping(ByteArray(0)))
-            resetPongDeadline(ws)
-        } catch (e: Exception) {
-            dropped.complete(e)
-            return
-        }
-
-        try {
-            while (scope.isActive) {
-                delay(pingPeriod)
+            // Send initial ping and start pong deadline.
+            try {
                 ws.send(WsFrame.Ping(ByteArray(0)))
+                resetPongDeadline(ws)
+            } catch (e: Exception) {
+                dropped.complete(e)
+                return
             }
-        } catch (_: CancellationException) {
-            // Normal shutdown.
-        } catch (e: Exception) {
-            dropped.complete(e)
-            logger.debug("wspulse/client: pingLoop error", e)
-        }
-    }
 
-    /**
-     * Reset the pong deadline timer. Called when a Pong frame is received.
-     *
-     * If the timer fires (no Pong within [HeartbeatConfig.pongWait]), the transport is closed,
-     * which triggers a transport drop.
-     */
-    private fun resetPongDeadline(ws: Transport) {
-        pongDeadlineJob?.cancel()
-        pongDeadlineJob =
+            try {
+                while (scope.isActive) {
+                    delay(pingPeriod)
+                    ws.send(WsFrame.Ping(ByteArray(0)))
+                }
+            } catch (_: CancellationException) {
+                // Normal shutdown.
+            } catch (e: Exception) {
+                dropped.complete(e)
+                logger.debug("wspulse/client: pingLoop error", e)
+            }
+        }
+
+        /**
+         * Reset the pong deadline timer. Called when a Pong frame is received.
+         *
+         * If the timer fires (no Pong within [HeartbeatConfig.pongWait]), the transport is closed,
+         * which triggers a transport drop.
+         */
+        private fun resetPongDeadline(ws: Transport) {
+            pongDeadlineJob?.cancel()
+            pongDeadlineJob =
                 scope.launch {
                     delay(config.heartbeat.pongWait)
                     logger.warn("wspulse/client: pong timeout, closing connection")
@@ -451,156 +452,156 @@ private constructor(
                         // already closing
                     }
                 }
-    }
-
-    // ── internal: reconnect ─────────────────────────────────────────────────
-
-    /**
-     * Handle an unexpected transport drop.
-     *
-     * If auto-reconnect is enabled, starts the reconnect loop. Otherwise, transitions to CLOSED
-     * immediately.
-     */
-    private fun handleTransportDrop(cause: Exception?) {
-        if (closed.get()) return
-        if (!reconnecting.compareAndSet(false, true)) return
-
-        // Cancel current connection coroutines.
-        connectionJob?.cancel()
-        pongDeadlineJob?.cancel()
-
-        val err = cause ?: Exception("wspulse: transport closed unexpectedly")
-        config.onTransportDrop(err)
-
-        if (config.autoReconnect != null) {
-            scope.launch { reconnectLoop() }
-        } else {
-            shutdown(ConnectionLostException(err))
         }
-    }
 
-    /**
-     * Reconnect loop with exponential backoff.
-     *
-     * Persistent loop — after a successful reconnect, waits for the new connection to drop before
-     * retrying. This eliminates the race window where a drop between [startConnection] and
-     * `reconnecting.set(false)` could be silently ignored.
-     *
-     * Stops when:
-     * - Max retries exhausted → CLOSED with [RetriesExhaustedException].
-     * - [close] called → CLOSED with `null`.
-     */
-    private suspend fun reconnectLoop() {
-        val rc = config.autoReconnect ?: return
-        var attempt = 0
+        // ── internal: reconnect ─────────────────────────────────────────────────
 
-        while (scope.isActive && !closed.get()) {
-            // Check max retries.
-            if (rc.maxRetries > 0 && attempt >= rc.maxRetries) {
-                shutdown(RetriesExhaustedException(attempt))
-                return
-            }
-
-            // Backoff delay.
-            val delayDuration = backoff(attempt, rc.baseDelay, rc.maxDelay)
-            logger.debug(
-                    "wspulse/client: backoff attempt={} delay={}",
-                    attempt,
-                    delayDuration,
-            )
-            try {
-                delay(delayDuration)
-            } catch (_: CancellationException) {
-                return // close() was called.
-            }
-
+        /**
+         * Handle an unexpected transport drop.
+         *
+         * If auto-reconnect is enabled, starts the reconnect loop. Otherwise, transitions to CLOSED
+         * immediately.
+         */
+        private fun handleTransportDrop(cause: Exception?) {
             if (closed.get()) return
+            if (!reconnecting.compareAndSet(false, true)) return
 
-            // Attempt to dial.
-            try {
-                val newTransport = dialOnce()
+            // Cancel current connection coroutines.
+            connectionJob?.cancel()
+            pongDeadlineJob?.cancel()
 
-                // Check if close() was called during dial.
-                if (closed.get()) {
-                    try {
-                        newTransport.close(CloseReason(CloseReason.Codes.NORMAL, ""))
-                    } catch (_: Exception) {
-                        // ignore
-                    }
+            val err = cause ?: Exception("wspulse: transport closed unexpectedly")
+            config.onTransportDrop(err)
+
+            if (config.autoReconnect != null) {
+                scope.launch { reconnectLoop() }
+            } else {
+                shutdown(ConnectionLostException(err))
+            }
+        }
+
+        /**
+         * Reconnect loop with exponential backoff.
+         *
+         * Persistent loop — after a successful reconnect, waits for the new connection to drop before
+         * retrying. This eliminates the race window where a drop between [startConnection] and
+         * `reconnecting.set(false)` could be silently ignored.
+         *
+         * Stops when:
+         * - Max retries exhausted → CLOSED with [RetriesExhaustedException].
+         * - [close] called → CLOSED with `null`.
+         */
+        private suspend fun reconnectLoop() {
+            val rc = config.autoReconnect ?: return
+            var attempt = 0
+
+            while (scope.isActive && !closed.get()) {
+                // Check max retries.
+                if (rc.maxRetries > 0 && attempt >= rc.maxRetries) {
+                    shutdown(RetriesExhaustedException(attempt))
                     return
                 }
 
-                // Start new connection loops and wait for drop.
-                val dropped = startConnection(newTransport)
-                reconnecting.set(false)
-                logger.info("wspulse/client: reconnected attempt={} url={}", attempt, url)
-
-                if (closed.get()) return
-
+                // Backoff delay.
+                val delayDuration = backoff(attempt, rc.baseDelay, rc.maxDelay)
+                logger.debug(
+                    "wspulse/client: backoff attempt={} delay={}",
+                    attempt,
+                    delayDuration,
+                )
                 try {
-                    config.onTransportRestore()
-                } catch (e: Exception) {
-                    logger.warn("wspulse/client: onTransportRestore callback threw", e)
-                }
-
-                // Wait for this connection to drop before looping.
-                val dropCause: Exception?
-                try {
-                    dropCause = dropped.await()
+                    delay(delayDuration)
                 } catch (_: CancellationException) {
                     return // close() was called.
                 }
+
                 if (closed.get()) return
 
-                // Prepare for next reconnect cycle.
-                reconnecting.set(true)
-                connectionJob?.cancel()
-                pongDeadlineJob?.cancel()
-                val dropErr = dropCause ?: Exception("wspulse: transport closed unexpectedly")
-                config.onTransportDrop(dropErr)
-                attempt = 0
-            } catch (e: Exception) {
-                logger.debug("wspulse/client: dial failed attempt={}", attempt, e)
-                attempt++
+                // Attempt to dial.
+                try {
+                    val newTransport = dialOnce()
+
+                    // Check if close() was called during dial.
+                    if (closed.get()) {
+                        try {
+                            newTransport.close(CloseReason(CloseReason.Codes.NORMAL, ""))
+                        } catch (_: Exception) {
+                            // ignore
+                        }
+                        return
+                    }
+
+                    // Start new connection loops and wait for drop.
+                    val dropped = startConnection(newTransport)
+                    reconnecting.set(false)
+                    logger.info("wspulse/client: reconnected attempt={} url={}", attempt, url)
+
+                    if (closed.get()) return
+
+                    try {
+                        config.onTransportRestore()
+                    } catch (e: Exception) {
+                        logger.warn("wspulse/client: onTransportRestore callback threw", e)
+                    }
+
+                    // Wait for this connection to drop before looping.
+                    val dropCause: Exception?
+                    try {
+                        dropCause = dropped.await()
+                    } catch (_: CancellationException) {
+                        return // close() was called.
+                    }
+                    if (closed.get()) return
+
+                    // Prepare for next reconnect cycle.
+                    reconnecting.set(true)
+                    connectionJob?.cancel()
+                    pongDeadlineJob?.cancel()
+                    val dropErr = dropCause ?: Exception("wspulse: transport closed unexpectedly")
+                    config.onTransportDrop(dropErr)
+                    attempt = 0
+                } catch (e: Exception) {
+                    logger.debug("wspulse/client: dial failed attempt={}", attempt, e)
+                    attempt++
+                }
             }
         }
-    }
 
-    // ── internal: shutdown ──────────────────────────────────────────────────
+        // ── internal: shutdown ──────────────────────────────────────────────────
 
-    /**
-     * Transition to CLOSED state. Releases all resources.
-     *
-     * @param err `null` for clean close, a [WspulseException] for abnormal disconnect.
-     */
-    private fun shutdown(err: WspulseException?) {
-        if (!shutdownOnce.compareAndSet(false, true)) return
+        /**
+         * Transition to CLOSED state. Releases all resources.
+         *
+         * @param err `null` for clean close, a [WspulseException] for abnormal disconnect.
+         */
+        private fun shutdown(err: WspulseException?) {
+            if (!shutdownOnce.compareAndSet(false, true)) return
 
-        logger.debug("wspulse/client: shutdown err={}", err)
+            logger.debug("wspulse/client: shutdown err={}", err)
 
-        // Cancel the scope so all child coroutines exit.
-        scope.coroutineContext[Job]?.cancel()
-        connectionJob?.cancel()
-        pongDeadlineJob?.cancel()
+            // Cancel the scope so all child coroutines exit.
+            scope.coroutineContext[Job]?.cancel()
+            connectionJob?.cancel()
+            pongDeadlineJob?.cancel()
 
-        // Release external resources (e.g. CIO HttpClient).
-        try {
-            onShutdown()
-        } catch (_: Exception) {
-            // ignore
+            // Release external resources (e.g. CIO HttpClient).
+            try {
+                onShutdown()
+            } catch (_: Exception) {
+                // ignore
+            }
+
+            // Fire onDisconnect exactly once.
+            try {
+                config.onDisconnect(err)
+            } catch (e: Exception) {
+                logger.warn("wspulse/client: onDisconnect callback threw", e)
+            }
+
+            // Resolve done.
+            _done.complete(Unit)
         }
-
-        // Fire onDisconnect exactly once.
-        try {
-            config.onDisconnect(err)
-        } catch (e: Exception) {
-            logger.warn("wspulse/client: onDisconnect callback threw", e)
-        }
-
-        // Resolve done.
-        _done.complete(Unit)
     }
-}
 
 /**
  * [Transport] backed by a Ktor [DefaultWebSocketSession].
@@ -608,7 +609,7 @@ private constructor(
  * Internal visibility — not part of the public API.
  */
 internal class RealTransport(
-        private val session: DefaultWebSocketSession,
+    private val session: DefaultWebSocketSession,
 ) : Transport {
     override val incoming
         get() = session.incoming
@@ -636,12 +637,12 @@ private fun normalizeScheme(url: String): String {
             val schemeEnd = url.indexOf("://")
             if (schemeEnd > 0) {
                 throw IllegalArgumentException(
-                        "wspulse: unsupported url scheme \"${url.substring(0, schemeEnd)}\"," +
-                                " use ws://, wss://, http://, or https://",
+                    "wspulse: unsupported url scheme \"${url.substring(0, schemeEnd)}\"," +
+                        " use ws://, wss://, http://, or https://",
                 )
             }
             throw IllegalArgumentException(
-                    "wspulse: url must include scheme (ws://, wss://, http://, or https://)",
+                "wspulse: url must include scheme (ws://, wss://, http://, or https://)",
             )
         }
     }

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.random.Random
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import io.ktor.websocket.Frame as WsFrame
@@ -99,6 +100,7 @@ class WspulseClient private constructor(
     private val dialer: Dialer,
     private val onShutdown: () -> Unit,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val random: Random = Random,
 ) : Client {
     companion object {
         private val logger = LoggerFactory.getLogger(WspulseClient::class.java)
@@ -160,8 +162,9 @@ class WspulseClient private constructor(
             dialer: Dialer,
             onShutdown: () -> Unit = {},
             dispatcher: CoroutineDispatcher = Dispatchers.IO,
+            random: Random = Random,
         ): Client {
-            val client = WspulseClient(url, config, dialer, onShutdown, dispatcher)
+            val client = WspulseClient(url, config, dialer, onShutdown, dispatcher, random)
 
             try {
                 val transport = client.dialOnce()
@@ -512,7 +515,7 @@ class WspulseClient private constructor(
             }
 
             // Backoff delay.
-            val delayDuration = backoff(attempt, rc.baseDelay, rc.maxDelay)
+            val delayDuration = backoff(attempt, rc.baseDelay, rc.maxDelay, random)
             logger.debug(
                 "wspulse/client: backoff attempt={} delay={}",
                 attempt,

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -7,10 +7,15 @@ import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.http.headers
 import io.ktor.websocket.CloseReason
 import io.ktor.websocket.DefaultWebSocketSession
+import io.ktor.websocket.Frame as WsFrame
 import io.ktor.websocket.close
 import io.ktor.websocket.send
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -24,16 +29,12 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.slf4j.LoggerFactory
-import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
-import io.ktor.websocket.Frame as WsFrame
 
 /**
  * Public interface for the wspulse WebSocket client.
  *
- * Obtained by calling [WspulseClient.connect]. Both [send] and [close] are
- * safe to call from any coroutine or thread.
+ * Obtained by calling [WspulseClient.connect]. Both [send] and [close] are safe to call from any
+ * coroutine or thread.
  */
 interface Client {
     /**
@@ -49,23 +50,21 @@ interface Client {
     /**
      * Permanently terminate the connection and stop any reconnect loop.
      *
-     * Suspends until all internal coroutines have exited. After this returns,
-     * the client holds no background resources. Idempotent: calling more than
-     * once is safe.
+     * Suspends until all internal coroutines have exited. After this returns, the client holds no
+     * background resources. Idempotent: calling more than once is safe.
      *
-     * Do not call `close()` synchronously from within any callback
-     * ([ClientConfig.onMessage], [ClientConfig.onDisconnect], etc.); the
-     * callback runs inside a tracked coroutine and waiting for it to exit
-     * would deadlock. Launch a separate coroutine if closing from a callback
-     * is required.
+     * Do not call `close()` synchronously from within any callback ([ClientConfig.onMessage],
+     * [ClientConfig.onDisconnect], etc.); the callback runs inside a tracked coroutine and waiting
+     * for it to exit would deadlock. Launch a separate coroutine if closing from a callback is
+     * required.
      */
     suspend fun close()
 
     /**
      * Completes when the client permanently disconnects.
      *
-     * This includes an explicit [close] call, a server-side drop when
-     * auto-reconnect is disabled, or max reconnect retries being exhausted.
+     * This includes an explicit [close] call, a server-side drop when auto-reconnect is disabled,
+     * or max reconnect retries being exhausted.
      */
     val done: Deferred<Unit>
 }
@@ -88,11 +87,13 @@ private const val MAX_RETRIES_LIMIT = 32
  * - RECONNECTING: transport dropped, backoff + retry in progress.
  * - CLOSED: permanently disconnected, all resources released.
  */
-class WspulseClient private constructor(
-    private val url: String,
-    private val config: ClientConfig,
-    private val dialer: Dialer,
-    private val onShutdown: () -> Unit,
+class WspulseClient
+private constructor(
+        private val url: String,
+        private val config: ClientConfig,
+        private val dialer: Dialer,
+        private val onShutdown: () -> Unit,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : Client {
     companion object {
         private val logger = LoggerFactory.getLogger(WspulseClient::class.java)
@@ -100,61 +101,65 @@ class WspulseClient private constructor(
         /**
          * Connect to a wspulse WebSocket server.
          *
-         * The initial dial is always fatal: if the handshake fails, the
-         * exception is propagated to the caller regardless of whether
-         * [ClientConfig.autoReconnect] is configured. No callbacks fire and
-         * no [Client] is returned to the caller. Auto-reconnect only activates
-         * after a successful initial connection subsequently drops.
+         * The initial dial is always fatal: if the handshake fails, the exception is propagated to
+         * the caller regardless of whether [ClientConfig.autoReconnect] is configured. No callbacks
+         * fire and no [Client] is returned to the caller. Auto-reconnect only activates after a
+         * successful initial connection subsequently drops.
          *
-         * @param url  WebSocket or HTTP URL (e.g. `wss://host/ws`).
+         * @param url WebSocket or HTTP URL (e.g. `wss://host/ws`).
+         * ```
          *             `http://` and `https://` schemes are auto-converted
          *             to `ws://` and `wss://` respectively.
-         * @param init DSL block to configure the client.
+         * @param init
+         * ```
+         * DSL block to configure the client.
          * @return A [Client] whose initial WebSocket handshake has completed
+         * ```
          *         successfully. The underlying transport is connected on a
          *         best-effort basis and may transition to reconnecting or closed
          *         state according to the configured lifecycle.
+         * ```
          */
         suspend fun connect(
-            url: String,
-            init: ClientConfig.() -> Unit = {},
+                url: String,
+                init: ClientConfig.() -> Unit = {},
         ): Client {
             val normalizedUrl = normalizeScheme(url)
             val config = ClientConfig().apply(init)
             validateConfig(config)
-            val httpClient =
-                HttpClient(CIO) {
-                    install(WebSockets)
-                }
+            val httpClient = HttpClient(CIO) { install(WebSockets) }
 
-            val dialer =
-                Dialer { dialUrl, dialHeaders ->
-                    val session =
+            val dialer = Dialer { dialUrl, dialHeaders ->
+                val session =
                         httpClient.webSocketSession(dialUrl) {
-                            headers {
-                                dialHeaders.forEach { (k, v) -> append(k, v) }
-                            }
+                            headers { dialHeaders.forEach { (k, v) -> append(k, v) } }
                         }
-                    RealTransport(session)
-                }
+                RealTransport(session)
+            }
 
-            return connectInternal(normalizedUrl, config, dialer) { httpClient.close() }
+            return connectInternal(
+                    normalizedUrl,
+                    config,
+                    dialer,
+                    onShutdown = { httpClient.close() }
+            )
         }
 
         /**
          * Internal connect for testing — accepts a custom [Dialer].
          *
-         * Not part of the public API. Callers must validate config and
-         * normalize the URL before calling.
+         * Not part of the public API. Callers must validate config and normalize the URL before
+         * calling.
          */
         @JvmSynthetic
         internal suspend fun connectInternal(
-            url: String,
-            config: ClientConfig,
-            dialer: Dialer,
-            onShutdown: () -> Unit = {},
+                url: String,
+                config: ClientConfig,
+                dialer: Dialer,
+                onShutdown: () -> Unit = {},
+                dispatcher: CoroutineDispatcher = Dispatchers.IO,
         ): Client {
-            val client = WspulseClient(url, config, dialer, onShutdown)
+            val client = WspulseClient(url, config, dialer, onShutdown, dispatcher)
 
             try {
                 val transport = client.dialOnce()
@@ -181,14 +186,15 @@ class WspulseClient private constructor(
     }
 
     /** Scope that owns all internal coroutines. */
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
     /** Bounded send channel. [send] uses [Channel.trySend] (non-blocking). */
     private val sendChannel = Channel<ByteArray>(config.sendBufferSize)
 
     /** Completes on permanent disconnect. */
     private val _done = CompletableDeferred<Unit>()
-    override val done: Deferred<Unit> get() = _done
+    override val done: Deferred<Unit>
+        get() = _done
 
     /** Guards [shutdown] to fire exactly once. */
     private val shutdownOnce = AtomicBoolean(false)
@@ -200,15 +206,13 @@ class WspulseClient private constructor(
     private val reconnecting = AtomicBoolean(false)
 
     /**
-     * Job for the current connection's coroutines (readLoop, writeLoop,
-     * pingLoop). Cancelled and replaced on each reconnect so old loops
-     * stop before new ones start.
+     * Job for the current connection's coroutines (readLoop, writeLoop, pingLoop). Cancelled and
+     * replaced on each reconnect so old loops stop before new ones start.
      */
     private var connectionJob: Job? = null
 
     /** Current transport. Guarded by [connectionJob] lifecycle. */
-    @Volatile
-    private var transport: Transport? = null
+    @Volatile private var transport: Transport? = null
 
     // ── public API ──────────────────────────────────────────────────────────
 
@@ -295,12 +299,11 @@ class WspulseClient private constructor(
     /**
      * Read incoming WebSocket frames, decode, and dispatch to onMessage.
      *
-     * Completes [dropped] when the transport's incoming channel closes
-     * (transport drop).
+     * Completes [dropped] when the transport's incoming channel closes (transport drop).
      */
     private suspend fun readLoop(
-        ws: Transport,
-        dropped: CompletableDeferred<Exception?>,
+            ws: Transport,
+            dropped: CompletableDeferred<Exception?>,
     ) {
         var readError: Exception? = null
         try {
@@ -308,22 +311,22 @@ class WspulseClient private constructor(
                 if (!scope.isActive) return
 
                 val data: ByteArray =
-                    when (wsFrame) {
-                        is WsFrame.Text -> wsFrame.data
-                        is WsFrame.Binary -> wsFrame.data
-                        is WsFrame.Pong -> {
-                            resetPongDeadline(ws)
-                            continue
+                        when (wsFrame) {
+                            is WsFrame.Text -> wsFrame.data
+                            is WsFrame.Binary -> wsFrame.data
+                            is WsFrame.Pong -> {
+                                resetPongDeadline(ws)
+                                continue
+                            }
+                            else -> continue
                         }
-                        else -> continue
-                    }
 
                 // maxMessageSize enforcement.
                 if (config.maxMessageSize > 0 && data.size.toLong() > config.maxMessageSize) {
                     logger.warn(
-                        "wspulse/client: message too large ({} > {}), closing",
-                        data.size,
-                        config.maxMessageSize,
+                            "wspulse/client: message too large ({} > {}), closing",
+                            data.size,
+                            config.maxMessageSize,
                     )
                     try {
                         ws.close(CloseReason(CloseReason.Codes.TOO_BIG, "message too large"))
@@ -364,23 +367,21 @@ class WspulseClient private constructor(
      * Each write is wrapped in [withTimeout] using [ClientConfig.writeWait].
      */
     private suspend fun writeLoop(
-        ws: Transport,
-        dropped: CompletableDeferred<Exception?>,
+            ws: Transport,
+            dropped: CompletableDeferred<Exception?>,
     ) {
         try {
             for (data in sendChannel) {
                 if (!scope.isActive) return
 
                 val wsFrame =
-                    when (config.codec.frameType) {
-                        FrameType.TEXT -> WsFrame.Text(String(data, Charsets.UTF_8))
-                        FrameType.BINARY -> WsFrame.Binary(true, data)
-                    }
+                        when (config.codec.frameType) {
+                            FrameType.TEXT -> WsFrame.Text(String(data, Charsets.UTF_8))
+                            FrameType.BINARY -> WsFrame.Binary(true, data)
+                        }
 
                 try {
-                    withTimeout(config.writeWait) {
-                        ws.send(wsFrame)
-                    }
+                    withTimeout(config.writeWait) { ws.send(wsFrame) }
                 } catch (e: Exception) {
                     if (e is CancellationException && !scope.isActive) throw e
                     logger.warn("wspulse/client: write failed", e)
@@ -401,15 +402,12 @@ class WspulseClient private constructor(
     // ── internal: heartbeat ─────────────────────────────────────────────────
 
     /** Job for the current pong deadline timer. Reset on each Pong received. */
-    @Volatile
-    private var pongDeadlineJob: Job? = null
+    @Volatile private var pongDeadlineJob: Job? = null
 
-    /**
-     * Send WebSocket Ping frames at [HeartbeatConfig.pingPeriod] intervals.
-     */
+    /** Send WebSocket Ping frames at [HeartbeatConfig.pingPeriod] intervals. */
     private suspend fun pingLoop(
-        ws: Transport,
-        dropped: CompletableDeferred<Exception?>,
+            ws: Transport,
+            dropped: CompletableDeferred<Exception?>,
     ) {
         val pingPeriod = config.heartbeat.pingPeriod
 
@@ -438,21 +436,21 @@ class WspulseClient private constructor(
     /**
      * Reset the pong deadline timer. Called when a Pong frame is received.
      *
-     * If the timer fires (no Pong within [HeartbeatConfig.pongWait]), the
-     * transport is closed, which triggers a transport drop.
+     * If the timer fires (no Pong within [HeartbeatConfig.pongWait]), the transport is closed,
+     * which triggers a transport drop.
      */
     private fun resetPongDeadline(ws: Transport) {
         pongDeadlineJob?.cancel()
         pongDeadlineJob =
-            scope.launch {
-                delay(config.heartbeat.pongWait)
-                logger.warn("wspulse/client: pong timeout, closing connection")
-                try {
-                    ws.close(CloseReason(CloseReason.Codes.GOING_AWAY, "pong timeout"))
-                } catch (_: Exception) {
-                    // already closing
+                scope.launch {
+                    delay(config.heartbeat.pongWait)
+                    logger.warn("wspulse/client: pong timeout, closing connection")
+                    try {
+                        ws.close(CloseReason(CloseReason.Codes.GOING_AWAY, "pong timeout"))
+                    } catch (_: Exception) {
+                        // already closing
+                    }
                 }
-            }
     }
 
     // ── internal: reconnect ─────────────────────────────────────────────────
@@ -460,8 +458,8 @@ class WspulseClient private constructor(
     /**
      * Handle an unexpected transport drop.
      *
-     * If auto-reconnect is enabled, starts the reconnect loop.
-     * Otherwise, transitions to CLOSED immediately.
+     * If auto-reconnect is enabled, starts the reconnect loop. Otherwise, transitions to CLOSED
+     * immediately.
      */
     private fun handleTransportDrop(cause: Exception?) {
         if (closed.get()) return
@@ -484,10 +482,9 @@ class WspulseClient private constructor(
     /**
      * Reconnect loop with exponential backoff.
      *
-     * Persistent loop — after a successful reconnect, waits for the new
-     * connection to drop before retrying. This eliminates the race window
-     * where a drop between [startConnection] and `reconnecting.set(false)`
-     * could be silently ignored.
+     * Persistent loop — after a successful reconnect, waits for the new connection to drop before
+     * retrying. This eliminates the race window where a drop between [startConnection] and
+     * `reconnecting.set(false)` could be silently ignored.
      *
      * Stops when:
      * - Max retries exhausted → CLOSED with [RetriesExhaustedException].
@@ -507,9 +504,9 @@ class WspulseClient private constructor(
             // Backoff delay.
             val delayDuration = backoff(attempt, rc.baseDelay, rc.maxDelay)
             logger.debug(
-                "wspulse/client: backoff attempt={} delay={}",
-                attempt,
-                delayDuration,
+                    "wspulse/client: backoff attempt={} delay={}",
+                    attempt,
+                    delayDuration,
             )
             try {
                 delay(delayDuration)
@@ -574,8 +571,7 @@ class WspulseClient private constructor(
     /**
      * Transition to CLOSED state. Releases all resources.
      *
-     * @param err `null` for clean close, a [WspulseException] for abnormal
-     *   disconnect.
+     * @param err `null` for clean close, a [WspulseException] for abnormal disconnect.
      */
     private fun shutdown(err: WspulseException?) {
         if (!shutdownOnce.compareAndSet(false, true)) return
@@ -612,9 +608,10 @@ class WspulseClient private constructor(
  * Internal visibility — not part of the public API.
  */
 internal class RealTransport(
-    private val session: DefaultWebSocketSession,
+        private val session: DefaultWebSocketSession,
 ) : Transport {
-    override val incoming get() = session.incoming
+    override val incoming
+        get() = session.incoming
 
     override suspend fun send(frame: WsFrame) = session.send(frame)
 
@@ -624,12 +621,10 @@ internal class RealTransport(
 /**
  * Normalize the URL scheme for WebSocket connections.
  *
- * Converts `http://` to `ws://` and `https://` to `wss://`.
- * `ws://` and `wss://` pass through unchanged.
- * Any other scheme (or missing scheme) throws [IllegalArgumentException].
+ * Converts `http://` to `ws://` and `https://` to `wss://`. `ws://` and `wss://` pass through
+ * unchanged. Any other scheme (or missing scheme) throws [IllegalArgumentException].
  *
- * Validates explicitly because Ktor's error messages for invalid
- * schemes are generic and unhelpful.
+ * Validates explicitly because Ktor's error messages for invalid schemes are generic and unhelpful.
  */
 private fun normalizeScheme(url: String): String {
     val lower = url.lowercase()
@@ -641,12 +636,12 @@ private fun normalizeScheme(url: String): String {
             val schemeEnd = url.indexOf("://")
             if (schemeEnd > 0) {
                 throw IllegalArgumentException(
-                    "wspulse: unsupported url scheme \"${url.substring(0, schemeEnd)}\"," +
-                        " use ws://, wss://, http://, or https://",
+                        "wspulse: unsupported url scheme \"${url.substring(0, schemeEnd)}\"," +
+                                " use ws://, wss://, http://, or https://",
                 )
             }
             throw IllegalArgumentException(
-                "wspulse: url must include scheme (ws://, wss://, http://, or https://)",
+                    "wspulse: url must include scheme (ws://, wss://, http://, or https://)",
             )
         }
     }
@@ -655,54 +650,36 @@ private fun normalizeScheme(url: String): String {
 /**
  * Validate [ClientConfig] values against upper bounds.
  *
- * Matches client-go's fail-fast validation. Called before any resources
- * are allocated so invalid config never leaks an [HttpClient].
+ * Matches client-go's fail-fast validation. Called before any resources are allocated so invalid
+ * config never leaks an [HttpClient].
  */
 private fun validateConfig(config: ClientConfig) {
-    require(config.sendBufferSize >= 1) {
-        "wspulse: sendBufferSize must be at least 1"
-    }
+    require(config.sendBufferSize >= 1) { "wspulse: sendBufferSize must be at least 1" }
     require(config.sendBufferSize <= MAX_SEND_BUFFER_SIZE) {
         "wspulse: sendBufferSize exceeds maximum ($MAX_SEND_BUFFER_SIZE)"
     }
 
-    require(config.maxMessageSize >= 0) {
-        "wspulse: maxMessageSize must be non-negative"
-    }
+    require(config.maxMessageSize >= 0) { "wspulse: maxMessageSize must be non-negative" }
     require(config.maxMessageSize <= MAX_MSG_SIZE_BYTES) {
         "wspulse: maxMessageSize exceeds maximum (64 MiB)"
     }
-    require(config.writeWait.isPositive()) {
-        "wspulse: writeWait must be positive"
-    }
-    require(config.writeWait <= MAX_WRITE_WAIT) {
-        "wspulse: writeWait exceeds maximum (30s)"
-    }
+    require(config.writeWait.isPositive()) { "wspulse: writeWait must be positive" }
+    require(config.writeWait <= MAX_WRITE_WAIT) { "wspulse: writeWait exceeds maximum (30s)" }
 
     val hb = config.heartbeat
-    require(hb.pingPeriod.isPositive()) {
-        "wspulse: heartbeat.pingPeriod must be positive"
-    }
+    require(hb.pingPeriod.isPositive()) { "wspulse: heartbeat.pingPeriod must be positive" }
     require(hb.pingPeriod <= MAX_PING_PERIOD) {
         "wspulse: heartbeat.pingPeriod exceeds maximum (1m)"
     }
-    require(hb.pongWait.isPositive()) {
-        "wspulse: heartbeat.pongWait must be positive"
-    }
-    require(hb.pongWait <= MAX_PONG_WAIT) {
-        "wspulse: heartbeat.pongWait exceeds maximum (2m)"
-    }
+    require(hb.pongWait.isPositive()) { "wspulse: heartbeat.pongWait must be positive" }
+    require(hb.pongWait <= MAX_PONG_WAIT) { "wspulse: heartbeat.pongWait exceeds maximum (2m)" }
     require(hb.pingPeriod < hb.pongWait) {
         "wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait"
     }
 
     config.autoReconnect?.let { rc ->
-        require(rc.maxRetries >= 0) {
-            "wspulse: autoReconnect.maxRetries must be non-negative"
-        }
-        require(rc.baseDelay.isPositive()) {
-            "wspulse: autoReconnect.baseDelay must be positive"
-        }
+        require(rc.maxRetries >= 0) { "wspulse: autoReconnect.maxRetries must be non-negative" }
+        require(rc.baseDelay.isPositive()) { "wspulse: autoReconnect.baseDelay must be positive" }
         require(rc.baseDelay <= MAX_BASE_DELAY) {
             "wspulse: autoReconnect.baseDelay exceeds maximum (1m)"
         }

--- a/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
@@ -6,12 +6,6 @@ import com.wspulse.client.Frame
 import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.withContext
@@ -22,6 +16,12 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Basic connect/send/receive component tests for [WspulseClient].
@@ -46,185 +46,185 @@ class BasicTest {
 
     @Test
     fun `connects, sends a frame, receives echo, and closes cleanly`() =
-            kotlinx.coroutines.test.runTest {
-                val received = CopyOnWriteArrayList<Frame>()
-                val disconnectErr = AtomicReference<WspulseException?>(null)
-                val disconnectCalled = CountDownLatch(1)
+        kotlinx.coroutines.test.runTest {
+            val received = CopyOnWriteArrayList<Frame>()
+            val disconnectErr = AtomicReference<WspulseException?>(null)
+            val disconnectCalled = CountDownLatch(1)
 
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
-                val dialer = MockDialer(listOf(Result.success(transport)))
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
+            val dialer = MockDialer(listOf(Result.success(transport)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig {
-                                    onMessage = { frame -> received.add(frame) }
-                                    onDisconnect = { err ->
-                                        disconnectErr.set(err)
-                                        disconnectCalled.countDown()
-                                    }
-                                },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onMessage = { frame -> received.add(frame) }
+                        onDisconnect = { err ->
+                            disconnectErr.set(err)
+                            disconnectCalled.countDown()
+                        }
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
 
-                // Respond to initial ping.
-                waitForPing(transport)
-                pongResponder.tick()
+            // Respond to initial ping.
+            waitForPing(transport)
+            pongResponder.tick()
 
-                // Client sends a frame.
-                client.send(Frame(event = "msg", payload = mapOf("text" to "hello")))
+            // Client sends a frame.
+            client.send(Frame(event = "msg", payload = mapOf("text" to "hello")))
 
-                // Wait for writeLoop to pick up the frame.
-                waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Text } }
+            // Wait for writeLoop to pick up the frame.
+            waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Text } }
 
-                // Simulate server echo.
-                transport.injectText("""{"event":"msg","payload":{"text":"hello"}}""")
+            // Simulate server echo.
+            transport.injectText("""{"event":"msg","payload":{"text":"hello"}}""")
 
-                waitUntil { received.size >= 1 }
+            waitUntil { received.size >= 1 }
 
-                assertEquals("msg", received[0].event)
-                assertEquals(mapOf("text" to "hello"), received[0].payload)
+            assertEquals("msg", received[0].event)
+            assertEquals(mapOf("text" to "hello"), received[0].payload)
 
-                client.close()
-                client.done.await()
+            client.close()
+            client.done.await()
 
-                assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
-                assertNull(disconnectErr.get())
-            }
+            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+            assertNull(disconnectErr.get())
+        }
 
     // ── Frame round-trip ────────────────────────────────────────────────────
 
     @Test
     fun `round-trips all Frame fields (event, payload)`() =
-            kotlinx.coroutines.test.runTest {
-                val received = CopyOnWriteArrayList<Frame>()
+        kotlinx.coroutines.test.runTest {
+            val received = CopyOnWriteArrayList<Frame>()
 
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
-                val dialer = MockDialer(listOf(Result.success(transport)))
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
+            val dialer = MockDialer(listOf(Result.success(transport)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig { onMessage = { frame -> received.add(frame) } },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig { onMessage = { frame -> received.add(frame) } },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
 
-                waitForPing(transport)
-                pongResponder.tick()
+            waitForPing(transport)
+            pongResponder.tick()
 
-                val outbound =
-                        Frame(
-                                event = "chat.message",
-                                payload =
-                                        mapOf(
-                                                "user" to "alice",
-                                                "text" to "hi",
-                                                "n" to 42,
-                                                "nested" to mapOf("ok" to true),
-                                        ),
-                        )
-                client.send(outbound)
+            val outbound =
+                Frame(
+                    event = "chat.message",
+                    payload =
+                        mapOf(
+                            "user" to "alice",
+                            "text" to "hi",
+                            "n" to 42,
+                            "nested" to mapOf("ok" to true),
+                        ),
+                )
+            client.send(outbound)
 
-                // Wait for the write to appear.
-                waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Text } }
+            // Wait for the write to appear.
+            waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Text } }
 
-                // Echo the exact wire bytes back.
-                val textFrame = transport.sent.first { it is io.ktor.websocket.Frame.Text }
-                transport.injectText(String(textFrame.data, Charsets.UTF_8))
+            // Echo the exact wire bytes back.
+            val textFrame = transport.sent.first { it is io.ktor.websocket.Frame.Text }
+            transport.injectText(String(textFrame.data, Charsets.UTF_8))
 
-                waitUntil { received.size >= 1 }
+            waitUntil { received.size >= 1 }
 
-                assertEquals(outbound, received[0])
-            }
+            assertEquals(outbound, received[0])
+        }
 
     // ── Server rejection (dial failure) ─────────────────────────────────────
 
     @Test
     fun `handles server rejection gracefully`() =
-            kotlinx.coroutines.test.runTest {
-                val dialer =
-                        MockDialer(
-                                listOf(Result.failure(Exception("wspulse: connection rejected"))),
-                        )
+        kotlinx.coroutines.test.runTest {
+            val dialer =
+                MockDialer(
+                    listOf(Result.failure(Exception("wspulse: connection rejected"))),
+                )
 
-                try {
-                    val client =
-                            WspulseClient.connectInternal(
-                                    "ws://test",
-                                    clientConfig {},
-                                    dialer,
-                                    dispatcher = UnconfinedTestDispatcher(testScheduler),
-                            )
-                    testClient = client
-                    fail("Expected exception from connectInternal")
-                } catch (e: Exception) {
-                    assertTrue(e.message?.isNotBlank() == true, "exception should have a message")
-                }
+            try {
+                val client =
+                    WspulseClient.connectInternal(
+                        "ws://test",
+                        clientConfig {},
+                        dialer,
+                        dispatcher = UnconfinedTestDispatcher(testScheduler),
+                    )
+                testClient = client
+                fail("Expected exception from connectInternal")
+            } catch (e: Exception) {
+                assertTrue(e.message?.isNotBlank() == true, "exception should have a message")
             }
+        }
 
     // ── Message ordering ────────────────────────────────────────────────────
 
     @Test
     fun `sends multiple frames and receives them in order`() =
-            kotlinx.coroutines.test.runTest {
-                val received = CopyOnWriteArrayList<Frame>()
+        kotlinx.coroutines.test.runTest {
+            val received = CopyOnWriteArrayList<Frame>()
 
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
-                val dialer = MockDialer(listOf(Result.success(transport)))
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
+            val dialer = MockDialer(listOf(Result.success(transport)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig { onMessage = { frame -> received.add(frame) } },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig { onMessage = { frame -> received.add(frame) } },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
 
-                waitForPing(transport)
-                pongResponder.tick()
+            waitForPing(transport)
+            pongResponder.tick()
 
-                val count = 10
-                for (i in 0 until count) {
-                    client.send(Frame(event = "seq", payload = mapOf("i" to i)))
-                }
-
-                // Wait for all writes.
-                waitUntil { transport.sent.count { it is io.ktor.websocket.Frame.Text } >= count }
-
-                // Echo each in order.
-                val textFrames = transport.sent.filterIsInstance<io.ktor.websocket.Frame.Text>()
-                for (f in textFrames) {
-                    transport.injectText(String(f.data, Charsets.UTF_8))
-                }
-
-                waitUntil { received.size >= count }
-
-                for (i in 0 until count) {
-                    assertEquals("seq", received[i].event)
-                    assertEquals(mapOf("i" to i), received[i].payload)
-                }
+            val count = 10
+            for (i in 0 until count) {
+                client.send(Frame(event = "seq", payload = mapOf("i" to i)))
             }
+
+            // Wait for all writes.
+            waitUntil { transport.sent.count { it is io.ktor.websocket.Frame.Text } >= count }
+
+            // Echo each in order.
+            val textFrames = transport.sent.filterIsInstance<io.ktor.websocket.Frame.Text>()
+            for (f in textFrames) {
+                transport.injectText(String(f.data, Charsets.UTF_8))
+            }
+
+            waitUntil { received.size >= count }
+
+            for (i in 0 until count) {
+                assertEquals("seq", received[i].event)
+                assertEquals(mapOf("i" to i), received[i].payload)
+            }
+        }
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
     /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
     private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-            ClientConfig().apply {
-                heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-                init()
-            }
+        ClientConfig().apply {
+            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+            init()
+        }
 
     private suspend fun waitUntil(
-            timeoutMs: Long = 5_000,
-            condition: () -> Boolean,
+        timeoutMs: Long = 5_000,
+        condition: () -> Boolean,
     ) {
         if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
         withContext(Dispatchers.Default) {

--- a/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
@@ -6,7 +6,14 @@ import com.wspulse.client.Frame
 import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.AfterEach
@@ -15,12 +22,6 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Basic connect/send/receive component tests for [WspulseClient].
@@ -45,184 +46,187 @@ class BasicTest {
 
     @Test
     fun `connects, sends a frame, receives echo, and closes cleanly`() =
-        kotlinx.coroutines.test.runTest {
-            val received = CopyOnWriteArrayList<Frame>()
-            val disconnectErr = AtomicReference<WspulseException?>(null)
-            val disconnectCalled = CountDownLatch(1)
+            kotlinx.coroutines.test.runTest {
+                val received = CopyOnWriteArrayList<Frame>()
+                val disconnectErr = AtomicReference<WspulseException?>(null)
+                val disconnectCalled = CountDownLatch(1)
 
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-            val dialer = MockDialer(listOf(Result.success(transport)))
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
+                val dialer = MockDialer(listOf(Result.success(transport)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onMessage = { frame -> received.add(frame) }
-                        onDisconnect = { err ->
-                            disconnectErr.set(err)
-                            disconnectCalled.countDown()
-                        }
-                    },
-                    dialer,
-                )
-            testClient = client
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig {
+                                    onMessage = { frame -> received.add(frame) }
+                                    onDisconnect = { err ->
+                                        disconnectErr.set(err)
+                                        disconnectCalled.countDown()
+                                    }
+                                },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
 
-            // Respond to initial ping.
-            waitForPing(transport)
-            pongResponder.tick()
+                // Respond to initial ping.
+                waitForPing(transport)
+                pongResponder.tick()
 
-            // Client sends a frame.
-            client.send(Frame(event = "msg", payload = mapOf("text" to "hello")))
+                // Client sends a frame.
+                client.send(Frame(event = "msg", payload = mapOf("text" to "hello")))
 
-            // Wait for writeLoop to pick up the frame.
-            waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Text } }
+                // Wait for writeLoop to pick up the frame.
+                waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Text } }
 
-            // Simulate server echo.
-            transport.injectText("""{"event":"msg","payload":{"text":"hello"}}""")
+                // Simulate server echo.
+                transport.injectText("""{"event":"msg","payload":{"text":"hello"}}""")
 
-            waitUntil { received.size >= 1 }
+                waitUntil { received.size >= 1 }
 
-            assertEquals("msg", received[0].event)
-            assertEquals(mapOf("text" to "hello"), received[0].payload)
+                assertEquals("msg", received[0].event)
+                assertEquals(mapOf("text" to "hello"), received[0].payload)
 
-            client.close()
-            client.done.await()
+                client.close()
+                client.done.await()
 
-            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
-            assertNull(disconnectErr.get())
-        }
+                assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+                assertNull(disconnectErr.get())
+            }
 
     // ── Frame round-trip ────────────────────────────────────────────────────
 
     @Test
     fun `round-trips all Frame fields (event, payload)`() =
-        kotlinx.coroutines.test.runTest {
-            val received = CopyOnWriteArrayList<Frame>()
+            kotlinx.coroutines.test.runTest {
+                val received = CopyOnWriteArrayList<Frame>()
 
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-            val dialer = MockDialer(listOf(Result.success(transport)))
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
+                val dialer = MockDialer(listOf(Result.success(transport)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onMessage = { frame -> received.add(frame) }
-                    },
-                    dialer,
-                )
-            testClient = client
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig { onMessage = { frame -> received.add(frame) } },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
 
-            waitForPing(transport)
-            pongResponder.tick()
+                waitForPing(transport)
+                pongResponder.tick()
 
-            val outbound =
-                Frame(
-                    event = "chat.message",
-                    payload =
-                        mapOf(
-                            "user" to "alice",
-                            "text" to "hi",
-                            "n" to 42,
-                            "nested" to mapOf("ok" to true),
-                        ),
-                )
-            client.send(outbound)
+                val outbound =
+                        Frame(
+                                event = "chat.message",
+                                payload =
+                                        mapOf(
+                                                "user" to "alice",
+                                                "text" to "hi",
+                                                "n" to 42,
+                                                "nested" to mapOf("ok" to true),
+                                        ),
+                        )
+                client.send(outbound)
 
-            // Wait for the write to appear.
-            waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Text } }
+                // Wait for the write to appear.
+                waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Text } }
 
-            // Echo the exact wire bytes back.
-            val textFrame = transport.sent.first { it is io.ktor.websocket.Frame.Text }
-            transport.injectText(String(textFrame.data, Charsets.UTF_8))
+                // Echo the exact wire bytes back.
+                val textFrame = transport.sent.first { it is io.ktor.websocket.Frame.Text }
+                transport.injectText(String(textFrame.data, Charsets.UTF_8))
 
-            waitUntil { received.size >= 1 }
+                waitUntil { received.size >= 1 }
 
-            assertEquals(outbound, received[0])
-        }
+                assertEquals(outbound, received[0])
+            }
 
     // ── Server rejection (dial failure) ─────────────────────────────────────
 
     @Test
     fun `handles server rejection gracefully`() =
-        kotlinx.coroutines.test.runTest {
-            val dialer =
-                MockDialer(
-                    listOf(Result.failure(Exception("wspulse: connection rejected"))),
-                )
+            kotlinx.coroutines.test.runTest {
+                val dialer =
+                        MockDialer(
+                                listOf(Result.failure(Exception("wspulse: connection rejected"))),
+                        )
 
-            try {
-                val client =
-                    WspulseClient.connectInternal("ws://test", clientConfig {}, dialer)
-                testClient = client
-                fail("Expected exception from connectInternal")
-            } catch (e: Exception) {
-                assertTrue(e.message?.isNotBlank() == true, "exception should have a message")
+                try {
+                    val client =
+                            WspulseClient.connectInternal(
+                                    "ws://test",
+                                    clientConfig {},
+                                    dialer,
+                                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                            )
+                    testClient = client
+                    fail("Expected exception from connectInternal")
+                } catch (e: Exception) {
+                    assertTrue(e.message?.isNotBlank() == true, "exception should have a message")
+                }
             }
-        }
 
     // ── Message ordering ────────────────────────────────────────────────────
 
     @Test
     fun `sends multiple frames and receives them in order`() =
-        kotlinx.coroutines.test.runTest {
-            val received = CopyOnWriteArrayList<Frame>()
+            kotlinx.coroutines.test.runTest {
+                val received = CopyOnWriteArrayList<Frame>()
 
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-            val dialer = MockDialer(listOf(Result.success(transport)))
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
+                val dialer = MockDialer(listOf(Result.success(transport)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onMessage = { frame -> received.add(frame) }
-                    },
-                    dialer,
-                )
-            testClient = client
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig { onMessage = { frame -> received.add(frame) } },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
 
-            waitForPing(transport)
-            pongResponder.tick()
+                waitForPing(transport)
+                pongResponder.tick()
 
-            val count = 10
-            for (i in 0 until count) {
-                client.send(Frame(event = "seq", payload = mapOf("i" to i)))
+                val count = 10
+                for (i in 0 until count) {
+                    client.send(Frame(event = "seq", payload = mapOf("i" to i)))
+                }
+
+                // Wait for all writes.
+                waitUntil { transport.sent.count { it is io.ktor.websocket.Frame.Text } >= count }
+
+                // Echo each in order.
+                val textFrames = transport.sent.filterIsInstance<io.ktor.websocket.Frame.Text>()
+                for (f in textFrames) {
+                    transport.injectText(String(f.data, Charsets.UTF_8))
+                }
+
+                waitUntil { received.size >= count }
+
+                for (i in 0 until count) {
+                    assertEquals("seq", received[i].event)
+                    assertEquals(mapOf("i" to i), received[i].payload)
+                }
             }
-
-            // Wait for all writes.
-            waitUntil {
-                transport.sent.count { it is io.ktor.websocket.Frame.Text } >= count
-            }
-
-            // Echo each in order.
-            val textFrames = transport.sent.filterIsInstance<io.ktor.websocket.Frame.Text>()
-            for (f in textFrames) {
-                transport.injectText(String(f.data, Charsets.UTF_8))
-            }
-
-            waitUntil { received.size >= count }
-
-            for (i in 0 until count) {
-                assertEquals("seq", received[i].event)
-                assertEquals(mapOf("i" to i), received[i].payload)
-            }
-        }
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
     /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
     private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-        ClientConfig().apply {
-            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-            init()
-        }
+            ClientConfig().apply {
+                heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+                init()
+            }
 
     private suspend fun waitUntil(
-        timeoutMs: Long = 5_000,
-        condition: () -> Boolean,
+            timeoutMs: Long = 5_000,
+            condition: () -> Boolean,
     ) {
+        if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
         withContext(Dispatchers.Default) {
             withTimeout(timeoutMs.milliseconds) {
                 while (!condition()) {
@@ -233,8 +237,6 @@ class BasicTest {
     }
 
     private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil {
-            transport.sent.any { it is io.ktor.websocket.Frame.Ping }
-        }
+        waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Ping } }
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
@@ -6,15 +6,6 @@ import com.wspulse.client.ClientConfig
 import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -22,6 +13,15 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertFalse
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 /**
  * Callback behavior component tests for [WspulseClient].
@@ -46,232 +46,238 @@ class CallbackTest {
 
     @Test
     fun `transport error fires onTransportDrop and onDisconnect without reconnect`() =
-        kotlinx.coroutines.test.runTest {
-            val transportDropErr = AtomicReference<Exception?>(null)
-            val transportDropped = CountDownLatch(1)
-            val disconnectErr = AtomicReference<WspulseException?>(null)
-            val disconnectCalled = CountDownLatch(1)
+            kotlinx.coroutines.test.runTest {
+                val transportDropErr = AtomicReference<Exception?>(null)
+                val transportDropped = CountDownLatch(1)
+                val disconnectErr = AtomicReference<WspulseException?>(null)
+                val disconnectCalled = CountDownLatch(1)
 
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-            val dialer = MockDialer(listOf(Result.success(transport)))
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
+                val dialer = MockDialer(listOf(Result.success(transport)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onTransportDrop = { err ->
-                            transportDropErr.set(err)
-                            transportDropped.countDown()
-                        }
-                        onDisconnect = { err ->
-                            disconnectErr.set(err)
-                            disconnectCalled.countDown()
-                        }
-                    },
-                    dialer,
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig {
+                                    onTransportDrop = { err ->
+                                        transportDropErr.set(err)
+                                        transportDropped.countDown()
+                                    }
+                                    onDisconnect = { err ->
+                                        disconnectErr.set(err)
+                                        disconnectCalled.countDown()
+                                    }
+                                },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
+
+                // Respond to initial ping.
+                waitForPing(transport)
+                pongResponder.tick()
+
+                // Simulate transport drop.
+                transport.injectClose()
+
+                // Both callbacks should fire.
+                assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
+                assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+
+                assertTrue(
+                        transportDropErr.get() != null,
+                        "onTransportDrop should receive a non-null error",
                 )
-            testClient = client
-
-            // Respond to initial ping.
-            waitForPing(transport)
-            pongResponder.tick()
-
-            // Simulate transport drop.
-            transport.injectClose()
-
-            // Both callbacks should fire.
-            assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
-            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
-
-            assertTrue(
-                transportDropErr.get() != null,
-                "onTransportDrop should receive a non-null error",
-            )
-            assertTrue(
-                disconnectErr.get() != null,
-                "onDisconnect should receive a non-null error",
-            )
-        }
+                assertTrue(
+                        disconnectErr.get() != null,
+                        "onDisconnect should receive a non-null error",
+                )
+            }
 
     // ── onDisconnect fires exactly once on close ────────────────────────────
 
     @Test
     fun `onDisconnect fires exactly once on close`() =
-        kotlinx.coroutines.test.runTest {
-            val disconnectCount = AtomicInteger(0)
+            kotlinx.coroutines.test.runTest {
+                val disconnectCount = AtomicInteger(0)
 
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-            val dialer = MockDialer(listOf(Result.success(transport)))
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
+                val dialer = MockDialer(listOf(Result.success(transport)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onDisconnect = { disconnectCount.incrementAndGet() }
-                    },
-                    dialer,
-                )
-            testClient = client
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig {
+                                    onDisconnect = { disconnectCount.incrementAndGet() }
+                                },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
 
-            waitForPing(transport)
-            pongResponder.tick()
+                waitForPing(transport)
+                pongResponder.tick()
 
-            client.close()
-            client.done.await()
+                client.close()
+                client.done.await()
 
-            // Brief window for any erroneous second call.
-            withContext(Dispatchers.Default) { delay(200) }
+                // Brief window for any erroneous second call.
+                testScheduler.advanceTimeBy(200)
 
-            assertEquals(1, disconnectCount.get())
-        }
+                assertEquals(1, disconnectCount.get())
+            }
 
     // ── onTransportRestore does not fire on initial connect ─────────────────
 
     @Test
     fun `onTransportRestore does not fire on initial connect`() =
-        kotlinx.coroutines.test.runTest {
-            val restoreFired =
-                java.util.concurrent.atomic
-                    .AtomicBoolean(false)
+            kotlinx.coroutines.test.runTest {
+                val restoreFired = java.util.concurrent.atomic.AtomicBoolean(false)
 
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-            val dialer = MockDialer(listOf(Result.success(transport)))
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
+                val dialer = MockDialer(listOf(Result.success(transport)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onTransportRestore = { restoreFired.set(true) }
-                    },
-                    dialer,
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig { onTransportRestore = { restoreFired.set(true) } },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
+
+                waitForPing(transport)
+                pongResponder.tick()
+
+                // Give time for any erroneous callback.
+                testScheduler.advanceTimeBy(500)
+
+                assertFalse(
+                        restoreFired.get(),
+                        "onTransportRestore must not fire on initial connect",
                 )
-            testClient = client
-
-            waitForPing(transport)
-            pongResponder.tick()
-
-            // Give time for any erroneous callback.
-            withContext(Dispatchers.Default) { delay(500) }
-
-            assertFalse(
-                restoreFired.get(),
-                "onTransportRestore must not fire on initial connect",
-            )
-        }
+            }
 
     // ── close from onTransportDrop suppresses onTransportRestore ────────────
 
     @Test
     fun `close from onTransportDrop suppresses onTransportRestore`() =
-        kotlinx.coroutines.test.runTest {
-            val restoreCount = AtomicInteger(0)
-            val disconnectCalled = CountDownLatch(1)
-            val disconnectErr = AtomicReference<WspulseException?>(null)
-            val transportDropped = CountDownLatch(1)
+            kotlinx.coroutines.test.runTest {
+                val restoreCount = AtomicInteger(0)
+                val disconnectCalled = CountDownLatch(1)
+                val disconnectErr = AtomicReference<WspulseException?>(null)
+                val transportDropped = CountDownLatch(1)
 
-            val transport1 = MockTransport()
-            val transport2 = MockTransport()
-            val pongResponder1 = transport1.autoPong()
-            val dialer =
-                MockDialer(listOf(Result.success(transport1), Result.success(transport2)))
+                val transport1 = MockTransport()
+                val transport2 = MockTransport()
+                val pongResponder1 = transport1.autoPong()
+                val dialer =
+                        MockDialer(listOf(Result.success(transport1), Result.success(transport2)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onTransportDrop = { transportDropped.countDown() }
-                        onTransportRestore = { restoreCount.incrementAndGet() }
-                        onDisconnect = { err ->
-                            disconnectErr.set(err)
-                            disconnectCalled.countDown()
-                        }
-                        autoReconnect =
-                            AutoReconnectConfig(
-                                maxRetries = 5,
-                                baseDelay = 1.milliseconds,
-                                maxDelay = 10.milliseconds,
-                            )
-                    },
-                    dialer,
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig {
+                                    onTransportDrop = { transportDropped.countDown() }
+                                    onTransportRestore = { restoreCount.incrementAndGet() }
+                                    onDisconnect = { err ->
+                                        disconnectErr.set(err)
+                                        disconnectCalled.countDown()
+                                    }
+                                    autoReconnect =
+                                            AutoReconnectConfig(
+                                                    maxRetries = 5,
+                                                    baseDelay = 1.milliseconds,
+                                                    maxDelay = 10.milliseconds,
+                                            )
+                                },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
+
+                waitForPing(transport1)
+                pongResponder1.tick()
+
+                // Drop the transport.
+                transport1.injectClose()
+
+                // Wait for transport drop, then close immediately.
+                assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
+                client.close()
+
+                assertTrue(disconnectCalled.await(10, TimeUnit.SECONDS))
+
+                // Brief window for any erroneous onTransportRestore call.
+                testScheduler.advanceTimeBy(500)
+
+                assertEquals(
+                        0,
+                        restoreCount.get(),
+                        "onTransportRestore must not fire after close()"
                 )
-            testClient = client
-
-            waitForPing(transport1)
-            pongResponder1.tick()
-
-            // Drop the transport.
-            transport1.injectClose()
-
-            // Wait for transport drop, then close immediately.
-            assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
-            client.close()
-
-            assertTrue(disconnectCalled.await(10, TimeUnit.SECONDS))
-
-            // Brief window for any erroneous onTransportRestore call.
-            withContext(Dispatchers.Default) { delay(500) }
-
-            assertEquals(0, restoreCount.get(), "onTransportRestore must not fire after close()")
-            assertNull(disconnectErr.get(), "close() should produce null disconnect error")
-        }
+                assertNull(disconnectErr.get(), "close() should produce null disconnect error")
+            }
 
     // ── Transport error fires onTransportDrop ───────────────────────────────
 
     @Test
     fun `transport error with exception fires onTransportDrop with that error`() =
-        kotlinx.coroutines.test.runTest {
-            val transportDropErr = AtomicReference<Exception?>(null)
-            val transportDropped = CountDownLatch(1)
-            val disconnectCalled = CountDownLatch(1)
+            kotlinx.coroutines.test.runTest {
+                val transportDropErr = AtomicReference<Exception?>(null)
+                val transportDropped = CountDownLatch(1)
+                val disconnectCalled = CountDownLatch(1)
 
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-            val dialer = MockDialer(listOf(Result.success(transport)))
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
+                val dialer = MockDialer(listOf(Result.success(transport)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onTransportDrop = { err ->
-                            transportDropErr.set(err)
-                            transportDropped.countDown()
-                        }
-                        onDisconnect = { disconnectCalled.countDown() }
-                    },
-                    dialer,
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig {
+                                    onTransportDrop = { err ->
+                                        transportDropErr.set(err)
+                                        transportDropped.countDown()
+                                    }
+                                    onDisconnect = { disconnectCalled.countDown() }
+                                },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
+
+                waitForPing(transport)
+                pongResponder.tick()
+
+                // Inject a transport error.
+                transport.injectError(Exception("connection reset"))
+
+                assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
+                assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+                assertTrue(
+                        transportDropErr.get()?.message?.contains("connection reset") == true,
+                        "onTransportDrop should propagate the error",
                 )
-            testClient = client
-
-            waitForPing(transport)
-            pongResponder.tick()
-
-            // Inject a transport error.
-            transport.injectError(Exception("connection reset"))
-
-            assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
-            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
-            assertTrue(
-                transportDropErr.get()?.message?.contains("connection reset") == true,
-                "onTransportDrop should propagate the error",
-            )
-        }
+            }
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
     /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
     private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-        ClientConfig().apply {
-            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-            init()
-        }
+            ClientConfig().apply {
+                heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+                init()
+            }
 
     private suspend fun waitUntil(
-        timeoutMs: Long = 5_000,
-        condition: () -> Boolean,
+            timeoutMs: Long = 5_000,
+            condition: () -> Boolean,
     ) {
+        if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
         withContext(Dispatchers.Default) {
             withTimeout(timeoutMs.milliseconds) {
                 while (!condition()) {
@@ -282,8 +288,6 @@ class CallbackTest {
     }
 
     private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil {
-            transport.sent.any { it is io.ktor.websocket.Frame.Ping }
-        }
+        waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Ping } }
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
@@ -6,13 +6,6 @@ import com.wspulse.client.ClientConfig
 import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.test.assertFalse
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.withContext
@@ -22,6 +15,13 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.assertFalse
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Callback behavior component tests for [WspulseClient].
@@ -46,236 +46,238 @@ class CallbackTest {
 
     @Test
     fun `transport error fires onTransportDrop and onDisconnect without reconnect`() =
-            kotlinx.coroutines.test.runTest {
-                val transportDropErr = AtomicReference<Exception?>(null)
-                val transportDropped = CountDownLatch(1)
-                val disconnectErr = AtomicReference<WspulseException?>(null)
-                val disconnectCalled = CountDownLatch(1)
+        kotlinx.coroutines.test.runTest {
+            val transportDropErr = AtomicReference<Exception?>(null)
+            val transportDropped = CountDownLatch(1)
+            val disconnectErr = AtomicReference<WspulseException?>(null)
+            val disconnectCalled = CountDownLatch(1)
 
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
-                val dialer = MockDialer(listOf(Result.success(transport)))
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
+            val dialer = MockDialer(listOf(Result.success(transport)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig {
-                                    onTransportDrop = { err ->
-                                        transportDropErr.set(err)
-                                        transportDropped.countDown()
-                                    }
-                                    onDisconnect = { err ->
-                                        disconnectErr.set(err)
-                                        disconnectCalled.countDown()
-                                    }
-                                },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
-
-                // Respond to initial ping.
-                waitForPing(transport)
-                pongResponder.tick()
-
-                // Simulate transport drop.
-                transport.injectClose()
-
-                // Both callbacks should fire.
-                assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
-                assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
-
-                assertTrue(
-                        transportDropErr.get() != null,
-                        "onTransportDrop should receive a non-null error",
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onTransportDrop = { err ->
+                            transportDropErr.set(err)
+                            transportDropped.countDown()
+                        }
+                        onDisconnect = { err ->
+                            disconnectErr.set(err)
+                            disconnectCalled.countDown()
+                        }
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
-                assertTrue(
-                        disconnectErr.get() != null,
-                        "onDisconnect should receive a non-null error",
-                )
-            }
+            testClient = client
+
+            // Respond to initial ping.
+            waitForPing(transport)
+            pongResponder.tick()
+
+            // Simulate transport drop.
+            transport.injectClose()
+
+            // Both callbacks should fire.
+            assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
+            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+
+            assertTrue(
+                transportDropErr.get() != null,
+                "onTransportDrop should receive a non-null error",
+            )
+            assertTrue(
+                disconnectErr.get() != null,
+                "onDisconnect should receive a non-null error",
+            )
+        }
 
     // ── onDisconnect fires exactly once on close ────────────────────────────
 
     @Test
     fun `onDisconnect fires exactly once on close`() =
-            kotlinx.coroutines.test.runTest {
-                val disconnectCount = AtomicInteger(0)
+        kotlinx.coroutines.test.runTest {
+            val disconnectCount = AtomicInteger(0)
 
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
-                val dialer = MockDialer(listOf(Result.success(transport)))
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
+            val dialer = MockDialer(listOf(Result.success(transport)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig {
-                                    onDisconnect = { disconnectCount.incrementAndGet() }
-                                },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onDisconnect = { disconnectCount.incrementAndGet() }
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
 
-                waitForPing(transport)
-                pongResponder.tick()
+            waitForPing(transport)
+            pongResponder.tick()
 
-                client.close()
-                client.done.await()
+            client.close()
+            client.done.await()
 
-                // Brief window for any erroneous second call.
-                testScheduler.advanceTimeBy(200)
+            // Brief window for any erroneous second call.
+            testScheduler.advanceTimeBy(200)
 
-                assertEquals(1, disconnectCount.get())
-            }
+            assertEquals(1, disconnectCount.get())
+        }
 
     // ── onTransportRestore does not fire on initial connect ─────────────────
 
     @Test
     fun `onTransportRestore does not fire on initial connect`() =
-            kotlinx.coroutines.test.runTest {
-                val restoreFired = java.util.concurrent.atomic.AtomicBoolean(false)
+        kotlinx.coroutines.test.runTest {
+            val restoreFired =
+                java.util.concurrent.atomic
+                    .AtomicBoolean(false)
 
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
-                val dialer = MockDialer(listOf(Result.success(transport)))
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
+            val dialer = MockDialer(listOf(Result.success(transport)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig { onTransportRestore = { restoreFired.set(true) } },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
-
-                waitForPing(transport)
-                pongResponder.tick()
-
-                // Give time for any erroneous callback.
-                testScheduler.advanceTimeBy(500)
-
-                assertFalse(
-                        restoreFired.get(),
-                        "onTransportRestore must not fire on initial connect",
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig { onTransportRestore = { restoreFired.set(true) } },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
-            }
+            testClient = client
+
+            waitForPing(transport)
+            pongResponder.tick()
+
+            // Give time for any erroneous callback.
+            testScheduler.advanceTimeBy(500)
+
+            assertFalse(
+                restoreFired.get(),
+                "onTransportRestore must not fire on initial connect",
+            )
+        }
 
     // ── close from onTransportDrop suppresses onTransportRestore ────────────
 
     @Test
     fun `close from onTransportDrop suppresses onTransportRestore`() =
-            kotlinx.coroutines.test.runTest {
-                val restoreCount = AtomicInteger(0)
-                val disconnectCalled = CountDownLatch(1)
-                val disconnectErr = AtomicReference<WspulseException?>(null)
-                val transportDropped = CountDownLatch(1)
+        kotlinx.coroutines.test.runTest {
+            val restoreCount = AtomicInteger(0)
+            val disconnectCalled = CountDownLatch(1)
+            val disconnectErr = AtomicReference<WspulseException?>(null)
+            val transportDropped = CountDownLatch(1)
 
-                val transport1 = MockTransport()
-                val transport2 = MockTransport()
-                val pongResponder1 = transport1.autoPong()
-                val dialer =
-                        MockDialer(listOf(Result.success(transport1), Result.success(transport2)))
+            val transport1 = MockTransport()
+            val transport2 = MockTransport()
+            val pongResponder1 = transport1.autoPong()
+            val dialer =
+                MockDialer(listOf(Result.success(transport1), Result.success(transport2)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig {
-                                    onTransportDrop = { transportDropped.countDown() }
-                                    onTransportRestore = { restoreCount.incrementAndGet() }
-                                    onDisconnect = { err ->
-                                        disconnectErr.set(err)
-                                        disconnectCalled.countDown()
-                                    }
-                                    autoReconnect =
-                                            AutoReconnectConfig(
-                                                    maxRetries = 5,
-                                                    baseDelay = 1.milliseconds,
-                                                    maxDelay = 10.milliseconds,
-                                            )
-                                },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
-
-                waitForPing(transport1)
-                pongResponder1.tick()
-
-                // Drop the transport.
-                transport1.injectClose()
-
-                // Wait for transport drop, then close immediately.
-                assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
-                client.close()
-
-                assertTrue(disconnectCalled.await(10, TimeUnit.SECONDS))
-
-                // Brief window for any erroneous onTransportRestore call.
-                testScheduler.advanceTimeBy(500)
-
-                assertEquals(
-                        0,
-                        restoreCount.get(),
-                        "onTransportRestore must not fire after close()"
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onTransportDrop = { transportDropped.countDown() }
+                        onTransportRestore = { restoreCount.incrementAndGet() }
+                        onDisconnect = { err ->
+                            disconnectErr.set(err)
+                            disconnectCalled.countDown()
+                        }
+                        autoReconnect =
+                            AutoReconnectConfig(
+                                maxRetries = 5,
+                                baseDelay = 1.milliseconds,
+                                maxDelay = 10.milliseconds,
+                            )
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
-                assertNull(disconnectErr.get(), "close() should produce null disconnect error")
-            }
+            testClient = client
+
+            waitForPing(transport1)
+            pongResponder1.tick()
+
+            // Drop the transport.
+            transport1.injectClose()
+
+            // Wait for transport drop, then close immediately.
+            assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
+            client.close()
+
+            assertTrue(disconnectCalled.await(10, TimeUnit.SECONDS))
+
+            // Brief window for any erroneous onTransportRestore call.
+            testScheduler.advanceTimeBy(500)
+
+            assertEquals(
+                0,
+                restoreCount.get(),
+                "onTransportRestore must not fire after close()",
+            )
+            assertNull(disconnectErr.get(), "close() should produce null disconnect error")
+        }
 
     // ── Transport error fires onTransportDrop ───────────────────────────────
 
     @Test
     fun `transport error with exception fires onTransportDrop with that error`() =
-            kotlinx.coroutines.test.runTest {
-                val transportDropErr = AtomicReference<Exception?>(null)
-                val transportDropped = CountDownLatch(1)
-                val disconnectCalled = CountDownLatch(1)
+        kotlinx.coroutines.test.runTest {
+            val transportDropErr = AtomicReference<Exception?>(null)
+            val transportDropped = CountDownLatch(1)
+            val disconnectCalled = CountDownLatch(1)
 
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
-                val dialer = MockDialer(listOf(Result.success(transport)))
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
+            val dialer = MockDialer(listOf(Result.success(transport)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig {
-                                    onTransportDrop = { err ->
-                                        transportDropErr.set(err)
-                                        transportDropped.countDown()
-                                    }
-                                    onDisconnect = { disconnectCalled.countDown() }
-                                },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
-
-                waitForPing(transport)
-                pongResponder.tick()
-
-                // Inject a transport error.
-                transport.injectError(Exception("connection reset"))
-
-                assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
-                assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
-                assertTrue(
-                        transportDropErr.get()?.message?.contains("connection reset") == true,
-                        "onTransportDrop should propagate the error",
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onTransportDrop = { err ->
+                            transportDropErr.set(err)
+                            transportDropped.countDown()
+                        }
+                        onDisconnect = { disconnectCalled.countDown() }
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
-            }
+            testClient = client
+
+            waitForPing(transport)
+            pongResponder.tick()
+
+            // Inject a transport error.
+            transport.injectError(Exception("connection reset"))
+
+            assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
+            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+            assertTrue(
+                transportDropErr.get()?.message?.contains("connection reset") == true,
+                "onTransportDrop should propagate the error",
+            )
+        }
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
     /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
     private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-            ClientConfig().apply {
-                heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-                init()
-            }
+        ClientConfig().apply {
+            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+            init()
+        }
 
     private suspend fun waitUntil(
-            timeoutMs: Long = 5_000,
-            condition: () -> Boolean,
+        timeoutMs: Long = 5_000,
+        condition: () -> Boolean,
     ) {
         if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
         withContext(Dispatchers.Default) {

--- a/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
@@ -6,11 +6,6 @@ import com.wspulse.client.ConnectionClosedException
 import com.wspulse.client.Frame
 import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.WspulseClient
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -21,6 +16,11 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Client lifecycle component tests for [WspulseClient].
@@ -45,118 +45,118 @@ class LifecycleTest {
 
     @Test
     fun `send after close throws ConnectionClosedException`() =
-            kotlinx.coroutines.test.runTest {
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
-                val dialer = MockDialer(listOf(Result.success(transport)))
+        kotlinx.coroutines.test.runTest {
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
+            val dialer = MockDialer(listOf(Result.success(transport)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig {},
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {},
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
 
-                waitForPing(transport)
-                pongResponder.tick()
+            waitForPing(transport)
+            pongResponder.tick()
 
-                client.close()
-                client.done.await()
+            client.close()
+            client.done.await()
 
-                assertThrows<ConnectionClosedException> { client.send(Frame(event = "msg")) }
-            }
+            assertThrows<ConnectionClosedException> { client.send(Frame(event = "msg")) }
+        }
 
     // ── Close idempotency ───────────────────────────────────────────────────
 
     @Test
     fun `close is idempotent`() =
-            kotlinx.coroutines.test.runTest {
-                val disconnectCount = AtomicInteger(0)
+        kotlinx.coroutines.test.runTest {
+            val disconnectCount = AtomicInteger(0)
 
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
-                val dialer = MockDialer(listOf(Result.success(transport)))
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
+            val dialer = MockDialer(listOf(Result.success(transport)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig {
-                                    onDisconnect = { disconnectCount.incrementAndGet() }
-                                },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onDisconnect = { disconnectCount.incrementAndGet() }
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
 
-                waitForPing(transport)
-                pongResponder.tick()
+            waitForPing(transport)
+            pongResponder.tick()
 
-                // Call close multiple times concurrently.
-                val jobs = (0 until 5).map { launch { client.close() } }
-                jobs.forEach { it.join() }
-                client.done.await()
+            // Call close multiple times concurrently.
+            val jobs = (0 until 5).map { launch { client.close() } }
+            jobs.forEach { it.join() }
+            client.done.await()
 
-                assertEquals(1, disconnectCount.get())
-            }
+            assertEquals(1, disconnectCount.get())
+        }
 
     // ── Scenario 9: close racing with transport drop ────────────────────────
 
     @Test
     fun `close racing with transport drop fires onDisconnect exactly once`() =
-            kotlinx.coroutines.test.runTest {
-                val disconnectCount = AtomicInteger(0)
-                val disconnectCalled = CountDownLatch(1)
+        kotlinx.coroutines.test.runTest {
+            val disconnectCount = AtomicInteger(0)
+            val disconnectCalled = CountDownLatch(1)
 
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
-                val dialer = MockDialer(listOf(Result.success(transport)))
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
+            val dialer = MockDialer(listOf(Result.success(transport)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig {
-                                    onDisconnect = {
-                                        disconnectCount.incrementAndGet()
-                                        disconnectCalled.countDown()
-                                    }
-                                },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onDisconnect = {
+                            disconnectCount.incrementAndGet()
+                            disconnectCalled.countDown()
+                        }
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
 
-                waitForPing(transport)
-                pongResponder.tick()
+            waitForPing(transport)
+            pongResponder.tick()
 
-                // Fire close() and transport drop simultaneously.
-                val dropJob = launch { transport.injectClose() }
-                val closeJob = launch { client.close() }
+            // Fire close() and transport drop simultaneously.
+            val dropJob = launch { transport.injectClose() }
+            val closeJob = launch { client.close() }
 
-                dropJob.join()
-                closeJob.join()
+            dropJob.join()
+            closeJob.join()
 
-                assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
 
-                // Brief window for any erroneous second call.
-                testScheduler.advanceTimeBy(200)
+            // Brief window for any erroneous second call.
+            testScheduler.advanceTimeBy(200)
 
-                assertEquals(1, disconnectCount.get())
-            }
+            assertEquals(1, disconnectCount.get())
+        }
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
     /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
     private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-            ClientConfig().apply {
-                heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-                init()
-            }
+        ClientConfig().apply {
+            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+            init()
+        }
 
     private suspend fun waitUntil(
-            timeoutMs: Long = 5_000,
-            condition: () -> Boolean,
+        timeoutMs: Long = 5_000,
+        condition: () -> Boolean,
     ) {
         if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
         withContext(Dispatchers.Default) {

--- a/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
@@ -6,9 +6,14 @@ import com.wspulse.client.ConnectionClosedException
 import com.wspulse.client.Frame
 import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.WspulseClient
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.AfterEach
@@ -16,11 +21,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Client lifecycle component tests for [WspulseClient].
@@ -45,116 +45,120 @@ class LifecycleTest {
 
     @Test
     fun `send after close throws ConnectionClosedException`() =
-        kotlinx.coroutines.test.runTest {
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-            val dialer = MockDialer(listOf(Result.success(transport)))
+            kotlinx.coroutines.test.runTest {
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
+                val dialer = MockDialer(listOf(Result.success(transport)))
 
-            val client = WspulseClient.connectInternal("ws://test", clientConfig {}, dialer)
-            testClient = client
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig {},
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
 
-            waitForPing(transport)
-            pongResponder.tick()
+                waitForPing(transport)
+                pongResponder.tick()
 
-            client.close()
-            client.done.await()
+                client.close()
+                client.done.await()
 
-            assertThrows<ConnectionClosedException> {
-                client.send(Frame(event = "msg"))
+                assertThrows<ConnectionClosedException> { client.send(Frame(event = "msg")) }
             }
-        }
 
     // ── Close idempotency ───────────────────────────────────────────────────
 
     @Test
     fun `close is idempotent`() =
-        kotlinx.coroutines.test.runTest {
-            val disconnectCount = AtomicInteger(0)
+            kotlinx.coroutines.test.runTest {
+                val disconnectCount = AtomicInteger(0)
 
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-            val dialer = MockDialer(listOf(Result.success(transport)))
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
+                val dialer = MockDialer(listOf(Result.success(transport)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onDisconnect = { disconnectCount.incrementAndGet() }
-                    },
-                    dialer,
-                )
-            testClient = client
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig {
+                                    onDisconnect = { disconnectCount.incrementAndGet() }
+                                },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
 
-            waitForPing(transport)
-            pongResponder.tick()
+                waitForPing(transport)
+                pongResponder.tick()
 
-            // Call close multiple times concurrently.
-            val jobs =
-                (0 until 5).map {
-                    launch { client.close() }
-                }
-            jobs.forEach { it.join() }
-            client.done.await()
+                // Call close multiple times concurrently.
+                val jobs = (0 until 5).map { launch { client.close() } }
+                jobs.forEach { it.join() }
+                client.done.await()
 
-            assertEquals(1, disconnectCount.get())
-        }
+                assertEquals(1, disconnectCount.get())
+            }
 
     // ── Scenario 9: close racing with transport drop ────────────────────────
 
     @Test
     fun `close racing with transport drop fires onDisconnect exactly once`() =
-        kotlinx.coroutines.test.runTest {
-            val disconnectCount = AtomicInteger(0)
-            val disconnectCalled = CountDownLatch(1)
+            kotlinx.coroutines.test.runTest {
+                val disconnectCount = AtomicInteger(0)
+                val disconnectCalled = CountDownLatch(1)
 
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-            val dialer = MockDialer(listOf(Result.success(transport)))
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
+                val dialer = MockDialer(listOf(Result.success(transport)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onDisconnect = {
-                            disconnectCount.incrementAndGet()
-                            disconnectCalled.countDown()
-                        }
-                    },
-                    dialer,
-                )
-            testClient = client
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig {
+                                    onDisconnect = {
+                                        disconnectCount.incrementAndGet()
+                                        disconnectCalled.countDown()
+                                    }
+                                },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
 
-            waitForPing(transport)
-            pongResponder.tick()
+                waitForPing(transport)
+                pongResponder.tick()
 
-            // Fire close() and transport drop simultaneously.
-            val dropJob = launch { transport.injectClose() }
-            val closeJob = launch { client.close() }
+                // Fire close() and transport drop simultaneously.
+                val dropJob = launch { transport.injectClose() }
+                val closeJob = launch { client.close() }
 
-            dropJob.join()
-            closeJob.join()
+                dropJob.join()
+                closeJob.join()
 
-            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+                assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
 
-            // Brief window for any erroneous second call.
-            withContext(Dispatchers.Default) { delay(200) }
+                // Brief window for any erroneous second call.
+                testScheduler.advanceTimeBy(200)
 
-            assertEquals(1, disconnectCount.get())
-        }
+                assertEquals(1, disconnectCount.get())
+            }
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
     /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
     private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-        ClientConfig().apply {
-            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-            init()
-        }
+            ClientConfig().apply {
+                heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+                init()
+            }
 
     private suspend fun waitUntil(
-        timeoutMs: Long = 5_000,
-        condition: () -> Boolean,
+            timeoutMs: Long = 5_000,
+            condition: () -> Boolean,
     ) {
+        if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
         withContext(Dispatchers.Default) {
             withTimeout(timeoutMs.milliseconds) {
                 while (!condition()) {
@@ -165,8 +169,6 @@ class LifecycleTest {
     }
 
     private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil {
-            transport.sent.any { it is io.ktor.websocket.Frame.Ping }
-        }
+        waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Ping } }
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
@@ -137,6 +137,7 @@ class MiscTest {
 
             // Advance past pong deadline (300 ms) then assert immediately.
             testScheduler.advanceTimeBy(350)
+            testScheduler.runCurrent()
 
             assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
 

--- a/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
@@ -7,12 +7,6 @@ import com.wspulse.client.Frame
 import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -23,6 +17,12 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Miscellaneous component tests for [WspulseClient].
@@ -47,116 +47,116 @@ class MiscTest {
 
     @Test
     fun `concurrent sends from multiple coroutines do not race`() =
-            kotlinx.coroutines.test.runTest {
-                val received = CopyOnWriteArrayList<Frame>()
+        kotlinx.coroutines.test.runTest {
+            val received = CopyOnWriteArrayList<Frame>()
 
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
-                val dialer = MockDialer(listOf(Result.success(transport)))
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
+            val dialer = MockDialer(listOf(Result.success(transport)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig { onMessage = { frame -> received.add(frame) } },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig { onMessage = { frame -> received.add(frame) } },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
 
-                waitForPing(transport)
-                pongResponder.tick()
+            waitForPing(transport)
+            pongResponder.tick()
 
-                val senders = 50
-                val msgsPerSender = 5
-                val total = senders * msgsPerSender
+            val senders = 50
+            val msgsPerSender = 5
+            val total = senders * msgsPerSender
 
-                // Launch concurrent senders.
-                val jobs =
-                        (0 until senders).map { s ->
-                            async {
-                                for (m in 0 until msgsPerSender) {
-                                    client.send(
-                                            Frame(
-                                                    event = "concurrent",
-                                                    payload = mapOf("s" to s, "m" to m)
-                                            ),
-                                    )
-                                }
-                            }
+            // Launch concurrent senders.
+            val jobs =
+                (0 until senders).map { s ->
+                    async {
+                        for (m in 0 until msgsPerSender) {
+                            client.send(
+                                Frame(
+                                    event = "concurrent",
+                                    payload = mapOf("s" to s, "m" to m),
+                                ),
+                            )
                         }
-                jobs.awaitAll()
-
-                // Wait for all writes to appear in the transport.
-                waitUntil(timeoutMs = 10_000) {
-                    transport.sent.count { it is io.ktor.websocket.Frame.Text } >= total
+                    }
                 }
+            jobs.awaitAll()
 
-                // Inject echoes.
-                val textFrames = transport.sent.filterIsInstance<io.ktor.websocket.Frame.Text>()
-                for (f in textFrames) {
-                    transport.injectText(String(f.data, Charsets.UTF_8))
-                }
-
-                waitUntil(timeoutMs = 10_000) { received.size >= total }
-
-                assertEquals(total, received.size)
-                assertTrue(received.all { it.event == "concurrent" })
+            // Wait for all writes to appear in the transport.
+            waitUntil(timeoutMs = 10_000) {
+                transport.sent.count { it is io.ktor.websocket.Frame.Text } >= total
             }
+
+            // Inject echoes.
+            val textFrames = transport.sent.filterIsInstance<io.ktor.websocket.Frame.Text>()
+            for (f in textFrames) {
+                transport.injectText(String(f.data, Charsets.UTF_8))
+            }
+
+            waitUntil(timeoutMs = 10_000) { received.size >= total }
+
+            assertEquals(total, received.size)
+            assertTrue(received.all { it.event == "concurrent" })
+        }
 
     // ── Scenario 7: pong timeout ────────────────────────────────────────────
 
     @Test
     fun `pong timeout triggers ConnectionLostException`() =
-            kotlinx.coroutines.test.runTest {
-                val disconnectErr = AtomicReference<WspulseException?>(null)
-                val disconnectCalled = CountDownLatch(1)
+        kotlinx.coroutines.test.runTest {
+            val disconnectErr = AtomicReference<WspulseException?>(null)
+            val disconnectCalled = CountDownLatch(1)
 
-                val transport = MockTransport()
-                // Do NOT auto-pong -- let the pong deadline fire.
-                val dialer = MockDialer(listOf(Result.success(transport)))
+            val transport = MockTransport()
+            // Do NOT auto-pong -- let the pong deadline fire.
+            val dialer = MockDialer(listOf(Result.success(transport)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig {
-                                    onDisconnect = { err ->
-                                        disconnectErr.set(err)
-                                        disconnectCalled.countDown()
-                                    }
-                                    heartbeat =
-                                            HeartbeatConfig(
-                                                    pingPeriod = 100.milliseconds,
-                                                    pongWait = 300.milliseconds,
-                                            )
-                                },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
-
-                // Advance past pong deadline (300 ms) then assert immediately.
-                testScheduler.advanceTimeBy(350)
-
-                assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
-
-                assertTrue(
-                        disconnectErr.get() is ConnectionLostException,
-                        "expected ConnectionLostException but got: ${disconnectErr.get()}",
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onDisconnect = { err ->
+                            disconnectErr.set(err)
+                            disconnectCalled.countDown()
+                        }
+                        heartbeat =
+                            HeartbeatConfig(
+                                pingPeriod = 100.milliseconds,
+                                pongWait = 300.milliseconds,
+                            )
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
-            }
+            testClient = client
+
+            // Advance past pong deadline (300 ms) then assert immediately.
+            testScheduler.advanceTimeBy(350)
+
+            assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
+
+            assertTrue(
+                disconnectErr.get() is ConnectionLostException,
+                "expected ConnectionLostException but got: ${disconnectErr.get()}",
+            )
+        }
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
     /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
     private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-            ClientConfig().apply {
-                heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-                init()
-            }
+        ClientConfig().apply {
+            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+            init()
+        }
 
     private suspend fun waitUntil(
-            timeoutMs: Long = 5_000,
-            condition: () -> Boolean,
+        timeoutMs: Long = 5_000,
+        condition: () -> Boolean,
     ) {
         if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
         withContext(Dispatchers.Default) {

--- a/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
@@ -7,21 +7,22 @@ import com.wspulse.client.Frame
 import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 /**
  * Miscellaneous component tests for [WspulseClient].
@@ -46,112 +47,118 @@ class MiscTest {
 
     @Test
     fun `concurrent sends from multiple coroutines do not race`() =
-        kotlinx.coroutines.test.runTest {
-            val received = CopyOnWriteArrayList<Frame>()
+            kotlinx.coroutines.test.runTest {
+                val received = CopyOnWriteArrayList<Frame>()
 
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-            val dialer = MockDialer(listOf(Result.success(transport)))
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
+                val dialer = MockDialer(listOf(Result.success(transport)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onMessage = { frame -> received.add(frame) }
-                    },
-                    dialer,
-                )
-            testClient = client
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig { onMessage = { frame -> received.add(frame) } },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
 
-            waitForPing(transport)
-            pongResponder.tick()
+                waitForPing(transport)
+                pongResponder.tick()
 
-            val senders = 50
-            val msgsPerSender = 5
-            val total = senders * msgsPerSender
+                val senders = 50
+                val msgsPerSender = 5
+                val total = senders * msgsPerSender
 
-            // Launch concurrent senders.
-            val jobs =
-                (0 until senders).map { s ->
-                    async {
-                        for (m in 0 until msgsPerSender) {
-                            client.send(
-                                Frame(event = "concurrent", payload = mapOf("s" to s, "m" to m)),
-                            )
+                // Launch concurrent senders.
+                val jobs =
+                        (0 until senders).map { s ->
+                            async {
+                                for (m in 0 until msgsPerSender) {
+                                    client.send(
+                                            Frame(
+                                                    event = "concurrent",
+                                                    payload = mapOf("s" to s, "m" to m)
+                                            ),
+                                    )
+                                }
+                            }
                         }
-                    }
+                jobs.awaitAll()
+
+                // Wait for all writes to appear in the transport.
+                waitUntil(timeoutMs = 10_000) {
+                    transport.sent.count { it is io.ktor.websocket.Frame.Text } >= total
                 }
-            jobs.awaitAll()
 
-            // Wait for all writes to appear in the transport.
-            waitUntil(timeoutMs = 10_000) {
-                transport.sent.count { it is io.ktor.websocket.Frame.Text } >= total
+                // Inject echoes.
+                val textFrames = transport.sent.filterIsInstance<io.ktor.websocket.Frame.Text>()
+                for (f in textFrames) {
+                    transport.injectText(String(f.data, Charsets.UTF_8))
+                }
+
+                waitUntil(timeoutMs = 10_000) { received.size >= total }
+
+                assertEquals(total, received.size)
+                assertTrue(received.all { it.event == "concurrent" })
             }
-
-            // Inject echoes.
-            val textFrames = transport.sent.filterIsInstance<io.ktor.websocket.Frame.Text>()
-            for (f in textFrames) {
-                transport.injectText(String(f.data, Charsets.UTF_8))
-            }
-
-            waitUntil(timeoutMs = 10_000) { received.size >= total }
-
-            assertEquals(total, received.size)
-            assertTrue(received.all { it.event == "concurrent" })
-        }
 
     // ── Scenario 7: pong timeout ────────────────────────────────────────────
 
     @Test
     fun `pong timeout triggers ConnectionLostException`() =
-        kotlinx.coroutines.test.runTest {
-            val disconnectErr = AtomicReference<WspulseException?>(null)
-            val disconnectCalled = CountDownLatch(1)
+            kotlinx.coroutines.test.runTest {
+                val disconnectErr = AtomicReference<WspulseException?>(null)
+                val disconnectCalled = CountDownLatch(1)
 
-            val transport = MockTransport()
-            // Do NOT auto-pong -- let the pong deadline fire.
-            val dialer = MockDialer(listOf(Result.success(transport)))
+                val transport = MockTransport()
+                // Do NOT auto-pong -- let the pong deadline fire.
+                val dialer = MockDialer(listOf(Result.success(transport)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onDisconnect = { err ->
-                            disconnectErr.set(err)
-                            disconnectCalled.countDown()
-                        }
-                        heartbeat =
-                            HeartbeatConfig(
-                                pingPeriod = 100.milliseconds,
-                                pongWait = 300.milliseconds,
-                            )
-                    },
-                    dialer,
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig {
+                                    onDisconnect = { err ->
+                                        disconnectErr.set(err)
+                                        disconnectCalled.countDown()
+                                    }
+                                    heartbeat =
+                                            HeartbeatConfig(
+                                                    pingPeriod = 100.milliseconds,
+                                                    pongWait = 300.milliseconds,
+                                            )
+                                },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
+
+                // Advance past pong deadline (300 ms) then assert immediately.
+                testScheduler.advanceTimeBy(350)
+
+                assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
+
+                assertTrue(
+                        disconnectErr.get() is ConnectionLostException,
+                        "expected ConnectionLostException but got: ${disconnectErr.get()}",
                 )
-            testClient = client
-
-            // Wait for pong timeout -> transport close -> disconnect.
-            assertTrue(disconnectCalled.await(10, TimeUnit.SECONDS))
-
-            assertTrue(
-                disconnectErr.get() is ConnectionLostException,
-                "expected ConnectionLostException but got: ${disconnectErr.get()}",
-            )
-        }
+            }
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
     /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
     private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-        ClientConfig().apply {
-            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-            init()
-        }
+            ClientConfig().apply {
+                heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+                init()
+            }
 
     private suspend fun waitUntil(
-        timeoutMs: Long = 5_000,
-        condition: () -> Boolean,
+            timeoutMs: Long = 5_000,
+            condition: () -> Boolean,
     ) {
+        if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
         withContext(Dispatchers.Default) {
             withTimeout(timeoutMs.milliseconds) {
                 while (!condition()) {
@@ -162,8 +169,6 @@ class MiscTest {
     }
 
     private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil {
-            transport.sent.any { it is io.ktor.websocket.Frame.Ping }
-        }
+        waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Ping } }
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
@@ -230,7 +230,7 @@ class ReconnectTest {
             transport.injectClose()
 
             // Wait for transport drop callback (fires eagerly with UnconfinedTestDispatcher).
-            transportDropSignal.await()
+            withTimeout(1.seconds) { transportDropSignal.await() }
 
             // Advance past initial backoff so the slow dial starts.
             testScheduler.advanceTimeBy(5)

--- a/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
@@ -10,13 +10,6 @@ import com.wspulse.client.RetriesExhaustedException
 import com.wspulse.client.Transport
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -27,6 +20,13 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Reconnect flow component tests for [WspulseClient].
@@ -51,204 +51,204 @@ class ReconnectTest {
 
     @Test
     fun `reconnects after transport drop and resumes message flow`() =
-            kotlinx.coroutines.test.runTest {
-                val received = CopyOnWriteArrayList<Frame>()
-                val transportRestored = CountDownLatch(1)
+        kotlinx.coroutines.test.runTest {
+            val received = CopyOnWriteArrayList<Frame>()
+            val transportRestored = CountDownLatch(1)
 
-                val transport1 = MockTransport()
-                val transport2 = MockTransport()
-                val pongResponder1 = transport1.autoPong()
-                val pongResponder2 = transport2.autoPong()
-                val dialer =
-                        MockDialer(listOf(Result.success(transport1), Result.success(transport2)))
+            val transport1 = MockTransport()
+            val transport2 = MockTransport()
+            val pongResponder1 = transport1.autoPong()
+            val pongResponder2 = transport2.autoPong()
+            val dialer =
+                MockDialer(listOf(Result.success(transport1), Result.success(transport2)))
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig {
-                                    onMessage = { frame -> received.add(frame) }
-                                    onTransportRestore = { transportRestored.countDown() }
-                                    autoReconnect =
-                                            AutoReconnectConfig(
-                                                    maxRetries = 5,
-                                                    baseDelay = 1.milliseconds,
-                                                    maxDelay = 10.milliseconds,
-                                            )
-                                },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onMessage = { frame -> received.add(frame) }
+                        onTransportRestore = { transportRestored.countDown() }
+                        autoReconnect =
+                            AutoReconnectConfig(
+                                maxRetries = 5,
+                                baseDelay = 1.milliseconds,
+                                maxDelay = 10.milliseconds,
+                            )
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
 
-                // Respond to initial ping on transport1.
-                waitForPing(transport1)
-                pongResponder1.tick()
+            // Respond to initial ping on transport1.
+            waitForPing(transport1)
+            pongResponder1.tick()
 
-                // Send a frame before drop.
-                client.send(Frame(event = "before", payload = "drop"))
-                waitUntil { transport1.sent.any { it is io.ktor.websocket.Frame.Text } }
-                transport1.injectText("""{"event":"before","payload":"drop"}""")
-                waitUntil { received.any { it.event == "before" } }
+            // Send a frame before drop.
+            client.send(Frame(event = "before", payload = "drop"))
+            waitUntil { transport1.sent.any { it is io.ktor.websocket.Frame.Text } }
+            transport1.injectText("""{"event":"before","payload":"drop"}""")
+            waitUntil { received.any { it.event == "before" } }
 
-                // Drop transport1.
-                transport1.injectClose()
+            // Drop transport1.
+            transport1.injectClose()
 
-                // Advance past reconnect backoff (1 ms base, 10 ms max) and tick pong on
-                // transport2.
-                testScheduler.advanceTimeBy(20)
-                pongResponder2.tick()
+            // Advance past reconnect backoff (1 ms base, 10 ms max) and tick pong on
+            // transport2.
+            testScheduler.advanceTimeBy(20)
+            pongResponder2.tick()
 
-                assertTrue(transportRestored.await(0, TimeUnit.MILLISECONDS))
+            assertTrue(transportRestored.await(0, TimeUnit.MILLISECONDS))
 
-                // Send after reconnect.
-                client.send(Frame(event = "after", payload = "reconnect"))
-                waitUntil { transport2.sent.any { it is io.ktor.websocket.Frame.Text } }
-                transport2.injectText("""{"event":"after","payload":"reconnect"}""")
-                waitUntil { received.any { it.event == "after" } }
-            }
+            // Send after reconnect.
+            client.send(Frame(event = "after", payload = "reconnect"))
+            waitUntil { transport2.sent.any { it is io.ktor.websocket.Frame.Text } }
+            transport2.injectText("""{"event":"after","payload":"reconnect"}""")
+            waitUntil { received.any { it.event == "after" } }
+        }
 
     // ── Scenario 4: max retries exhausted ───────────────────────────────────
 
     @Test
     fun `fires RetriesExhaustedException after max retries exhausted`() =
-            kotlinx.coroutines.test.runTest {
-                val disconnectErr = AtomicReference<WspulseException?>(null)
-                val disconnectCalled = CountDownLatch(1)
+        kotlinx.coroutines.test.runTest {
+            val disconnectErr = AtomicReference<WspulseException?>(null)
+            val disconnectCalled = CountDownLatch(1)
 
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
 
-                // Initial transport succeeds, all reconnect dials fail.
-                val dialer =
-                        MockDialer(
-                                listOf(
-                                        Result.success(transport),
-                                        Result.failure(Exception("dial failed")),
-                                        Result.failure(Exception("dial failed")),
-                                ),
-                        )
-
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig {
-                                    onDisconnect = { err ->
-                                        disconnectErr.set(err)
-                                        disconnectCalled.countDown()
-                                    }
-                                    autoReconnect =
-                                            AutoReconnectConfig(
-                                                    maxRetries = 2,
-                                                    baseDelay = 1.milliseconds,
-                                                    maxDelay = 10.milliseconds,
-                                            )
-                                },
-                                dialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
-
-                // Respond to initial ping.
-                waitForPing(transport)
-                pongResponder.tick()
-
-                // Drop the transport to start reconnect loop.
-                transport.injectClose()
-
-                // Advance past all backoff delays for 2 retry attempts.
-                testScheduler.advanceTimeBy(50)
-
-                assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
-
-                assertTrue(
-                        disconnectErr.get() is RetriesExhaustedException,
-                        "expected RetriesExhaustedException but got: ${disconnectErr.get()}",
+            // Initial transport succeeds, all reconnect dials fail.
+            val dialer =
+                MockDialer(
+                    listOf(
+                        Result.success(transport),
+                        Result.failure(Exception("dial failed")),
+                        Result.failure(Exception("dial failed")),
+                    ),
                 )
-            }
+
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onDisconnect = { err ->
+                            disconnectErr.set(err)
+                            disconnectCalled.countDown()
+                        }
+                        autoReconnect =
+                            AutoReconnectConfig(
+                                maxRetries = 2,
+                                baseDelay = 1.milliseconds,
+                                maxDelay = 10.milliseconds,
+                            )
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
+
+            // Respond to initial ping.
+            waitForPing(transport)
+            pongResponder.tick()
+
+            // Drop the transport to start reconnect loop.
+            transport.injectClose()
+
+            // Advance past all backoff delays for 2 retry attempts.
+            testScheduler.advanceTimeBy(50)
+
+            assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
+
+            assertTrue(
+                disconnectErr.get() is RetriesExhaustedException,
+                "expected RetriesExhaustedException but got: ${disconnectErr.get()}",
+            )
+        }
 
     // ── Scenario 5: close during reconnect ──────────────────────────────────
 
     @Test
     fun `close during reconnect fires onDisconnect null`() =
-            kotlinx.coroutines.test.runTest {
-                val disconnectErr = AtomicReference<WspulseException?>(null)
-                val disconnectCalled = CountDownLatch(1)
-                val transportDropSignal = CompletableDeferred<Unit>()
+        kotlinx.coroutines.test.runTest {
+            val disconnectErr = AtomicReference<WspulseException?>(null)
+            val disconnectCalled = CountDownLatch(1)
+            val transportDropSignal = CompletableDeferred<Unit>()
 
-                val transport = MockTransport()
-                val pongResponder = transport.autoPong()
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
 
-                // Initial transport succeeds, reconnect dials fail (slow).
-                val slowDialer =
-                        object : Dialer {
-                            private val first = AtomicInteger(0)
+            // Initial transport succeeds, reconnect dials fail (slow).
+            val slowDialer =
+                object : Dialer {
+                    private val first = AtomicInteger(0)
 
-                            override suspend fun dial(
-                                    url: String,
-                                    headers: Map<String, String>,
-                            ): Transport {
-                                if (first.getAndIncrement() == 0) {
-                                    return transport
-                                }
-                                // Simulate slow dial that will be cancelled.
-                                delay(60.seconds)
-                                throw Exception("should not reach here")
-                            }
+                    override suspend fun dial(
+                        url: String,
+                        headers: Map<String, String>,
+                    ): Transport {
+                        if (first.getAndIncrement() == 0) {
+                            return transport
                         }
+                        // Simulate slow dial that will be cancelled.
+                        delay(60.seconds)
+                        throw Exception("should not reach here")
+                    }
+                }
 
-                val client =
-                        WspulseClient.connectInternal(
-                                "ws://test",
-                                clientConfig {
-                                    onDisconnect = { err ->
-                                        disconnectErr.set(err)
-                                        disconnectCalled.countDown()
-                                    }
-                                    onTransportDrop = { transportDropSignal.complete(Unit) }
-                                    autoReconnect =
-                                            AutoReconnectConfig(
-                                                    maxRetries = 10,
-                                                    baseDelay = 1.milliseconds,
-                                                    maxDelay = 10.milliseconds,
-                                            )
-                                },
-                                slowDialer,
-                                dispatcher = UnconfinedTestDispatcher(testScheduler),
-                        )
-                testClient = client
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onDisconnect = { err ->
+                            disconnectErr.set(err)
+                            disconnectCalled.countDown()
+                        }
+                        onTransportDrop = { transportDropSignal.complete(Unit) }
+                        autoReconnect =
+                            AutoReconnectConfig(
+                                maxRetries = 10,
+                                baseDelay = 1.milliseconds,
+                                maxDelay = 10.milliseconds,
+                            )
+                    },
+                    slowDialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
 
-                // Respond to initial ping.
-                waitForPing(transport)
-                pongResponder.tick()
+            // Respond to initial ping.
+            waitForPing(transport)
+            pongResponder.tick()
 
-                // Drop to trigger reconnect.
-                transport.injectClose()
+            // Drop to trigger reconnect.
+            transport.injectClose()
 
-                // Wait for transport drop callback (fires eagerly with UnconfinedTestDispatcher).
-                transportDropSignal.await()
+            // Wait for transport drop callback (fires eagerly with UnconfinedTestDispatcher).
+            transportDropSignal.await()
 
-                // Advance past initial backoff so the slow dial starts.
-                testScheduler.advanceTimeBy(5)
+            // Advance past initial backoff so the slow dial starts.
+            testScheduler.advanceTimeBy(5)
 
-                // Close during reconnect.
-                client.close()
+            // Close during reconnect.
+            client.close()
 
-                assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
-                assertNull(disconnectErr.get())
-            }
+            assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
+            assertNull(disconnectErr.get())
+        }
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
     /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
     private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-            ClientConfig().apply {
-                heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-                init()
-            }
+        ClientConfig().apply {
+            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+            init()
+        }
 
     private suspend fun waitUntil(
-            timeoutMs: Long = 5_000,
-            condition: () -> Boolean,
+        timeoutMs: Long = 5_000,
+        condition: () -> Boolean,
     ) {
         if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
         withContext(Dispatchers.Default) {

--- a/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
@@ -10,15 +10,6 @@ import com.wspulse.client.RetriesExhaustedException
 import com.wspulse.client.Transport
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -26,6 +17,16 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 /**
  * Reconnect flow component tests for [WspulseClient].
@@ -50,211 +51,206 @@ class ReconnectTest {
 
     @Test
     fun `reconnects after transport drop and resumes message flow`() =
-        kotlinx.coroutines.test.runTest {
-            val received = CopyOnWriteArrayList<Frame>()
-            val transportRestored = CountDownLatch(1)
+            kotlinx.coroutines.test.runTest {
+                val received = CopyOnWriteArrayList<Frame>()
+                val transportRestored = CountDownLatch(1)
 
-            val transport1 = MockTransport()
-            val transport2 = MockTransport()
-            val pongResponder1 = transport1.autoPong()
-            val pongResponder2 = transport2.autoPong()
-            val dialer = MockDialer(listOf(Result.success(transport1), Result.success(transport2)))
+                val transport1 = MockTransport()
+                val transport2 = MockTransport()
+                val pongResponder1 = transport1.autoPong()
+                val pongResponder2 = transport2.autoPong()
+                val dialer =
+                        MockDialer(listOf(Result.success(transport1), Result.success(transport2)))
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onMessage = { frame -> received.add(frame) }
-                        onTransportRestore = { transportRestored.countDown() }
-                        autoReconnect =
-                            AutoReconnectConfig(
-                                maxRetries = 5,
-                                baseDelay = 1.milliseconds,
-                                maxDelay = 10.milliseconds,
-                            )
-                    },
-                    dialer,
-                )
-            testClient = client
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig {
+                                    onMessage = { frame -> received.add(frame) }
+                                    onTransportRestore = { transportRestored.countDown() }
+                                    autoReconnect =
+                                            AutoReconnectConfig(
+                                                    maxRetries = 5,
+                                                    baseDelay = 1.milliseconds,
+                                                    maxDelay = 10.milliseconds,
+                                            )
+                                },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
 
-            // Respond to initial ping on transport1.
-            waitForPing(transport1)
-            pongResponder1.tick()
+                // Respond to initial ping on transport1.
+                waitForPing(transport1)
+                pongResponder1.tick()
 
-            // Send a frame before drop.
-            client.send(Frame(event = "before", payload = "drop"))
-            waitUntil { transport1.sent.any { it is io.ktor.websocket.Frame.Text } }
-            transport1.injectText("""{"event":"before","payload":"drop"}""")
-            waitUntil { received.any { it.event == "before" } }
+                // Send a frame before drop.
+                client.send(Frame(event = "before", payload = "drop"))
+                waitUntil { transport1.sent.any { it is io.ktor.websocket.Frame.Text } }
+                transport1.injectText("""{"event":"before","payload":"drop"}""")
+                waitUntil { received.any { it.event == "before" } }
 
-            // Drop transport1.
-            transport1.injectClose()
+                // Drop transport1.
+                transport1.injectClose()
 
-            // Auto-pong on transport2 after reconnect.
-            withContext(Dispatchers.Default) {
-                withTimeout(5.seconds) {
-                    while (dialer.dialCount < 2) {
-                        pongResponder1.tick()
-                        delay(10)
-                    }
-                }
+                // Advance past reconnect backoff (1 ms base, 10 ms max) and tick pong on
+                // transport2.
+                testScheduler.advanceTimeBy(20)
+                pongResponder2.tick()
+
+                assertTrue(transportRestored.await(0, TimeUnit.MILLISECONDS))
+
+                // Send after reconnect.
+                client.send(Frame(event = "after", payload = "reconnect"))
+                waitUntil { transport2.sent.any { it is io.ktor.websocket.Frame.Text } }
+                transport2.injectText("""{"event":"after","payload":"reconnect"}""")
+                waitUntil { received.any { it.event == "after" } }
             }
-
-            // Wait for reconnect and respond to pings on transport2.
-            withContext(Dispatchers.Default) {
-                withTimeout(5.seconds) {
-                    while (!transportRestored.await(10, TimeUnit.MILLISECONDS)) {
-                        pongResponder2.tick()
-                        delay(10)
-                    }
-                }
-            }
-
-            // Send after reconnect.
-            client.send(Frame(event = "after", payload = "reconnect"))
-            waitUntil { transport2.sent.any { it is io.ktor.websocket.Frame.Text } }
-            transport2.injectText("""{"event":"after","payload":"reconnect"}""")
-            waitUntil { received.any { it.event == "after" } }
-        }
 
     // ── Scenario 4: max retries exhausted ───────────────────────────────────
 
     @Test
     fun `fires RetriesExhaustedException after max retries exhausted`() =
-        kotlinx.coroutines.test.runTest {
-            val disconnectErr = AtomicReference<WspulseException?>(null)
-            val disconnectCalled = CountDownLatch(1)
+            kotlinx.coroutines.test.runTest {
+                val disconnectErr = AtomicReference<WspulseException?>(null)
+                val disconnectCalled = CountDownLatch(1)
 
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
 
-            // Initial transport succeeds, all reconnect dials fail.
-            val dialer =
-                MockDialer(
-                    listOf(
-                        Result.success(transport),
-                        Result.failure(Exception("dial failed")),
-                        Result.failure(Exception("dial failed")),
-                    ),
+                // Initial transport succeeds, all reconnect dials fail.
+                val dialer =
+                        MockDialer(
+                                listOf(
+                                        Result.success(transport),
+                                        Result.failure(Exception("dial failed")),
+                                        Result.failure(Exception("dial failed")),
+                                ),
+                        )
+
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig {
+                                    onDisconnect = { err ->
+                                        disconnectErr.set(err)
+                                        disconnectCalled.countDown()
+                                    }
+                                    autoReconnect =
+                                            AutoReconnectConfig(
+                                                    maxRetries = 2,
+                                                    baseDelay = 1.milliseconds,
+                                                    maxDelay = 10.milliseconds,
+                                            )
+                                },
+                                dialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
+
+                // Respond to initial ping.
+                waitForPing(transport)
+                pongResponder.tick()
+
+                // Drop the transport to start reconnect loop.
+                transport.injectClose()
+
+                // Advance past all backoff delays for 2 retry attempts.
+                testScheduler.advanceTimeBy(50)
+
+                assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
+
+                assertTrue(
+                        disconnectErr.get() is RetriesExhaustedException,
+                        "expected RetriesExhaustedException but got: ${disconnectErr.get()}",
                 )
-
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onDisconnect = { err ->
-                            disconnectErr.set(err)
-                            disconnectCalled.countDown()
-                        }
-                        autoReconnect =
-                            AutoReconnectConfig(
-                                maxRetries = 2,
-                                baseDelay = 1.milliseconds,
-                                maxDelay = 10.milliseconds,
-                            )
-                    },
-                    dialer,
-                )
-            testClient = client
-
-            // Respond to initial ping.
-            waitForPing(transport)
-            pongResponder.tick()
-
-            // Drop the transport to start reconnect loop.
-            transport.injectClose()
-
-            // Wait for retries to exhaust.
-            assertTrue(disconnectCalled.await(10, TimeUnit.SECONDS))
-
-            assertTrue(
-                disconnectErr.get() is RetriesExhaustedException,
-                "expected RetriesExhaustedException but got: ${disconnectErr.get()}",
-            )
-        }
+            }
 
     // ── Scenario 5: close during reconnect ──────────────────────────────────
 
     @Test
     fun `close during reconnect fires onDisconnect null`() =
-        kotlinx.coroutines.test.runTest {
-            val disconnectErr = AtomicReference<WspulseException?>(null)
-            val disconnectCalled = CountDownLatch(1)
-            val transportDropSignal = CompletableDeferred<Unit>()
+            kotlinx.coroutines.test.runTest {
+                val disconnectErr = AtomicReference<WspulseException?>(null)
+                val disconnectCalled = CountDownLatch(1)
+                val transportDropSignal = CompletableDeferred<Unit>()
 
-            val transport = MockTransport()
-            val pongResponder = transport.autoPong()
+                val transport = MockTransport()
+                val pongResponder = transport.autoPong()
 
-            // Initial transport succeeds, reconnect dials fail (slow).
-            val slowDialer =
-                object : Dialer {
-                    private val first = AtomicInteger(0)
+                // Initial transport succeeds, reconnect dials fail (slow).
+                val slowDialer =
+                        object : Dialer {
+                            private val first = AtomicInteger(0)
 
-                    override suspend fun dial(
-                        url: String,
-                        headers: Map<String, String>,
-                    ): Transport {
-                        if (first.getAndIncrement() == 0) {
-                            return transport
+                            override suspend fun dial(
+                                    url: String,
+                                    headers: Map<String, String>,
+                            ): Transport {
+                                if (first.getAndIncrement() == 0) {
+                                    return transport
+                                }
+                                // Simulate slow dial that will be cancelled.
+                                delay(60.seconds)
+                                throw Exception("should not reach here")
+                            }
                         }
-                        // Simulate slow dial that will be cancelled.
-                        delay(60.seconds)
-                        throw Exception("should not reach here")
-                    }
-                }
 
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onDisconnect = { err ->
-                            disconnectErr.set(err)
-                            disconnectCalled.countDown()
-                        }
-                        onTransportDrop = { transportDropSignal.complete(Unit) }
-                        autoReconnect =
-                            AutoReconnectConfig(
-                                maxRetries = 10,
-                                baseDelay = 1.milliseconds,
-                                maxDelay = 10.milliseconds,
-                            )
-                    },
-                    slowDialer,
-                )
-            testClient = client
+                val client =
+                        WspulseClient.connectInternal(
+                                "ws://test",
+                                clientConfig {
+                                    onDisconnect = { err ->
+                                        disconnectErr.set(err)
+                                        disconnectCalled.countDown()
+                                    }
+                                    onTransportDrop = { transportDropSignal.complete(Unit) }
+                                    autoReconnect =
+                                            AutoReconnectConfig(
+                                                    maxRetries = 10,
+                                                    baseDelay = 1.milliseconds,
+                                                    maxDelay = 10.milliseconds,
+                                            )
+                                },
+                                slowDialer,
+                                dispatcher = UnconfinedTestDispatcher(testScheduler),
+                        )
+                testClient = client
 
-            // Respond to initial ping.
-            waitForPing(transport)
-            pongResponder.tick()
+                // Respond to initial ping.
+                waitForPing(transport)
+                pongResponder.tick()
 
-            // Drop to trigger reconnect.
-            transport.injectClose()
+                // Drop to trigger reconnect.
+                transport.injectClose()
 
-            // Wait for transport drop callback.
-            withContext(Dispatchers.Default) {
-                withTimeout(5.seconds) { transportDropSignal.await() }
+                // Wait for transport drop callback (fires eagerly with UnconfinedTestDispatcher).
+                transportDropSignal.await()
+
+                // Advance past initial backoff so the slow dial starts.
+                testScheduler.advanceTimeBy(5)
+
+                // Close during reconnect.
+                client.close()
+
+                assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
+                assertNull(disconnectErr.get())
             }
-
-            // Close during reconnect.
-            client.close()
-
-            assertTrue(disconnectCalled.await(10, TimeUnit.SECONDS))
-            assertNull(disconnectErr.get())
-        }
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
     /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
     private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-        ClientConfig().apply {
-            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-            init()
-        }
+            ClientConfig().apply {
+                heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+                init()
+            }
 
     private suspend fun waitUntil(
-        timeoutMs: Long = 5_000,
-        condition: () -> Boolean,
+            timeoutMs: Long = 5_000,
+            condition: () -> Boolean,
     ) {
+        if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
         withContext(Dispatchers.Default) {
             withTimeout(timeoutMs.milliseconds) {
                 while (!condition()) {
@@ -265,8 +261,6 @@ class ReconnectTest {
     }
 
     private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil {
-            transport.sent.any { it is io.ktor.websocket.Frame.Ping }
-        }
+        waitUntil { transport.sent.any { it is io.ktor.websocket.Frame.Ping } }
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -78,6 +79,7 @@ class ReconnectTest {
                     },
                     dialer,
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
+                    random = Random(42),
                 )
             testClient = client
 
@@ -146,6 +148,7 @@ class ReconnectTest {
                     },
                     dialer,
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
+                    random = Random(42),
                 )
             testClient = client
 
@@ -215,6 +218,7 @@ class ReconnectTest {
                     },
                     slowDialer,
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
+                    random = Random(42),
                 )
             testClient = client
 

--- a/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
@@ -100,6 +100,7 @@ class ReconnectTest {
             // transport2.
             testScheduler.advanceTimeBy(20)
             pongResponder2.tick()
+            testScheduler.runCurrent()
 
             assertTrue(transportRestored.await(0, TimeUnit.MILLISECONDS))
 
@@ -161,6 +162,7 @@ class ReconnectTest {
 
             // Advance past all backoff delays for 2 retry attempts.
             testScheduler.advanceTimeBy(50)
+            testScheduler.runCurrent()
 
             assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
 


### PR DESCRIPTION
## Summary

Inject `CoroutineDispatcher` and `Random` into `WspulseClient` internals so component tests can use `UnconfinedTestDispatcher` for virtual time control, eliminating real-time delays and nondeterministic jitter.

Addresses wspulse/.github#22.

## Changes

- `WspulseClient.kt`: accept optional `dispatcher` and `random` parameters in internal `connectInternal()`; use dispatcher for internal `CoroutineScope`, random for backoff jitter
- `Backoff.kt`: accept `Random` parameter instead of using `Random.Default`
- `Transport.kt` / `MockTransport.kt`: minor adjustments for dispatcher-aware testing
- All component tests (`BasicTest`, `CallbackTest`, `LifecycleTest`, `MiscTest`, `ReconnectTest`): inject `UnconfinedTestDispatcher()`, use `advanceUntilIdle()` / `advanceTimeBy()` for deterministic time control
- `CHANGELOG.md` entry under [Unreleased]

## Checklist

### Required

- [x] `make check` passes (lint → test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] `send()` and `close()` remain safe for concurrent use from multiple coroutines