### PR TITLE
bug: onTransportDrop fires on user close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `onTransportDrop` callback signature changed from `(Exception) -> Unit` to `(Exception?) -> Unit`. The callback now fires on user-initiated close with `null`, guaranteeing it always fires exactly once per connection lifecycle.
+
 ---
 
 ## [0.5.0] - 2026-04-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **BREAKING**: `onTransportDrop` callback signature changed from `(Exception) -> Unit` to `(Exception?) -> Unit`. The callback now fires on user-initiated close with `null`, guaranteeing it always fires exactly once per connection lifecycle.
+- **BREAKING**: `onTransportDrop` callback signature changed from `(Exception) -> Unit` to `(Exception?) -> Unit`. The callback now fires with `null` on clean/user-initiated close, and fires exactly once per transport lifecycle. In reconnect scenarios each transport drop produces one invocation; a subsequent clean `close()` produces one more.
 
 ---
 

--- a/src/main/kotlin/com/wspulse/client/ClientConfig.kt
+++ b/src/main/kotlin/com/wspulse/client/ClientConfig.kt
@@ -6,8 +6,9 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * Configuration for a wspulse WebSocket client, built via the DSL in [WspulseClient.connect].
  *
- * All callback properties default to no-ops. Callbacks are invoked on an internal coroutine —
- * implementations must not block.
+ * All callback properties default to no-ops. Callbacks may be invoked on an internal coroutine
+ * (transport drop, reconnect) or on the caller's coroutine during user-initiated shutdown
+ * (e.g. [Client.close]). Implementations must not block.
  */
 class ClientConfig {
     /** Called for every application-level frame received from the server. */

--- a/src/main/kotlin/com/wspulse/client/ClientConfig.kt
+++ b/src/main/kotlin/com/wspulse/client/ClientConfig.kt
@@ -4,11 +4,10 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Configuration for a wspulse WebSocket client, built via the DSL in
- * [WspulseClient.connect].
+ * Configuration for a wspulse WebSocket client, built via the DSL in [WspulseClient.connect].
  *
- * All callback properties default to no-ops. Callbacks are invoked on an
- * internal coroutine — implementations must not block.
+ * All callback properties default to no-ops. Callbacks are invoked on an internal coroutine —
+ * implementations must not block.
  */
 class ClientConfig {
     /** Called for every application-level frame received from the server. */
@@ -17,29 +16,28 @@ class ClientConfig {
     /**
      * Called exactly once when the client permanently disconnects.
      *
-     * A `null` argument means graceful close via [Client.close].
-     * A non-null [WspulseException] indicates the reason for disconnection.
+     * A `null` argument means graceful close via [Client.close]. A non-null [WspulseException]
+     * indicates the reason for disconnection.
      */
     var onDisconnect: (WspulseException?) -> Unit = {}
 
     /**
-     * Called after a successful reconnect when the new transport is ready.
-     * Does not fire on the initial connection.
-     * Replaces the former `onReconnect` callback.
+     * Called after a successful reconnect when the new transport is ready. Does not fire on the
+     * initial connection. Replaces the former `onReconnect` callback.
      */
     var onTransportRestore: () -> Unit = {}
 
     /**
-     * Called when the underlying transport drops unexpectedly.
+     * Called each time the underlying transport closes.
      *
-     * If auto-reconnect is enabled, the client will attempt to reconnect
-     * after this callback returns. If disabled, [onDisconnect] follows.
+     * Fires with `null` on a clean [Client.close] call, or with the transport error on unexpected
+     * drops. When [Client.close] is called while reconnecting, this callback does not fire again.
      */
-    var onTransportDrop: (Exception) -> Unit = {}
+    var onTransportDrop: (Exception?) -> Unit = {}
 
     /**
-     * Auto-reconnect configuration. `null` disables auto-reconnect
-     * (transport drop becomes a permanent disconnect).
+     * Auto-reconnect configuration. `null` disables auto-reconnect (transport drop becomes a
+     * permanent disconnect).
      */
     var autoReconnect: AutoReconnectConfig? = null
 
@@ -49,7 +47,10 @@ class ClientConfig {
     /** Maximum time to wait for a write to complete before treating it as a transport failure. */
     var writeWait: Duration = 10.seconds
 
-    /** Maximum incoming message size in bytes. Messages exceeding this are rejected. Set to 0 to disable size enforcement. */
+    /**
+     * Maximum incoming message size in bytes. Messages exceeding this are rejected. Set to 0 to
+     * disable size enforcement.
+     */
     var maxMessageSize: Long = 1L shl 20 // 1 MiB
 
     /** Additional HTTP headers sent during the WebSocket handshake. */
@@ -61,8 +62,8 @@ class ClientConfig {
     /**
      * Capacity of the internal send buffer (number of frames).
      *
-     * Must be between 1 and 4096 inclusive. Larger values allow more frames
-     * to be queued during brief disconnections or bursty sends.
+     * Must be between 1 and 4096 inclusive. Larger values allow more frames to be queued during
+     * brief disconnections or bursty sends.
      */
     var sendBufferSize: Int = 256
 }
@@ -84,8 +85,7 @@ data class AutoReconnectConfig(
  * Heartbeat (ping/pong) timing parameters.
  *
  * @param pingPeriod Interval between outgoing pings.
- * @param pongWait Maximum time to wait for a pong reply before treating the
- *   connection as dead.
+ * @param pongWait Maximum time to wait for a pong reply before treating the connection as dead.
  */
 data class HeartbeatConfig(
     val pingPeriod: Duration = 20.seconds,

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -112,19 +112,12 @@ class WspulseClient
              * fire and no [Client] is returned to the caller. Auto-reconnect only activates after a
              * successful initial connection subsequently drops.
              *
-             * @param url WebSocket or HTTP URL (e.g. `wss://host/ws`).
-             * ```
-             *             `http://` and `https://` schemes are auto-converted
-             *             to `ws://` and `wss://` respectively.
-             * @param init
-             * ```
-             * DSL block to configure the client.
-             * @return A [Client] whose initial WebSocket handshake has completed
-             * ```
-             *         successfully. The underlying transport is connected on a
-             *         best-effort basis and may transition to reconnecting or closed
-             *         state according to the configured lifecycle.
-             * ```
+             * @param url WebSocket or HTTP URL (e.g. `wss://host/ws`). `http://` and `https://`
+             *   schemes are auto-converted to `ws://` and `wss://` respectively.
+             * @param init DSL block to configure the client.
+             * @return A [Client] whose initial WebSocket handshake has completed successfully.
+             *   The underlying transport is connected on a best-effort basis and may transition
+             *   to reconnecting or closed state according to the configured lifecycle.
              */
             suspend fun connect(
                 url: String,

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -38,8 +38,8 @@ import io.ktor.websocket.Frame as WsFrame
 /**
  * Public interface for the wspulse WebSocket client.
  *
- * Obtained by calling [WspulseClient.connect]. Both [send] and [close] are
- * safe to call from any coroutine or thread.
+ * Obtained by calling [WspulseClient.connect]. Both [send] and [close] are safe to call from any
+ * coroutine or thread.
  */
 interface Client {
     /**
@@ -55,23 +55,21 @@ interface Client {
     /**
      * Permanently terminate the connection and stop any reconnect loop.
      *
-     * Suspends until all internal coroutines have exited. After this returns,
-     * the client holds no background resources. Idempotent: calling more than
-     * once is safe.
+     * Suspends until all internal coroutines have exited. After this returns, the client holds no
+     * background resources. Idempotent: calling more than once is safe.
      *
-     * Do not call `close()` synchronously from within any callback
-     * ([ClientConfig.onMessage], [ClientConfig.onDisconnect], etc.); the
-     * callback runs inside a tracked coroutine and waiting for it to exit
-     * would deadlock. Launch a separate coroutine if closing from a callback
-     * is required.
+     * Do not call `close()` synchronously from within any callback ([ClientConfig.onMessage],
+     * [ClientConfig.onDisconnect], etc.); the callback runs inside a tracked coroutine and waiting
+     * for it to exit would deadlock. Launch a separate coroutine if closing from a callback is
+     * required.
      */
     suspend fun close()
 
     /**
      * Completes when the client permanently disconnects.
      *
-     * This includes an explicit [close] call, a server-side drop when
-     * auto-reconnect is disabled, or max reconnect retries being exhausted.
+     * This includes an explicit [close] call, a server-side drop when auto-reconnect is disabled,
+     * or max reconnect retries being exhausted.
      */
     val done: Deferred<Unit>
 }
@@ -94,534 +92,541 @@ private const val MAX_RETRIES_LIMIT = 32
  * - RECONNECTING: transport dropped, backoff + retry in progress.
  * - CLOSED: permanently disconnected, all resources released.
  */
-class WspulseClient private constructor(
-    private val url: String,
-    private val config: ClientConfig,
-    private val dialer: Dialer,
-    private val onShutdown: () -> Unit,
-    dispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val random: Random = Random.Default,
-) : Client {
-    companion object {
-        private val logger = LoggerFactory.getLogger(WspulseClient::class.java)
+class WspulseClient
+    private constructor(
+        private val url: String,
+        private val config: ClientConfig,
+        private val dialer: Dialer,
+        private val onShutdown: () -> Unit,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        private val random: Random = Random.Default,
+    ) : Client {
+        companion object {
+            private val logger = LoggerFactory.getLogger(WspulseClient::class.java)
 
-        /**
-         * Connect to a wspulse WebSocket server.
-         *
-         * The initial dial is always fatal: if the handshake fails, the
-         * exception is propagated to the caller regardless of whether
-         * [ClientConfig.autoReconnect] is configured. No callbacks fire and
-         * no [Client] is returned to the caller. Auto-reconnect only activates
-         * after a successful initial connection subsequently drops.
-         *
-         * @param url  WebSocket or HTTP URL (e.g. `wss://host/ws`).
-         *             `http://` and `https://` schemes are auto-converted
-         *             to `ws://` and `wss://` respectively.
-         * @param init DSL block to configure the client.
-         * @return A [Client] whose initial WebSocket handshake has completed
-         *         successfully. The underlying transport is connected on a
-         *         best-effort basis and may transition to reconnecting or closed
-         *         state according to the configured lifecycle.
-         */
-        suspend fun connect(
-            url: String,
-            init: ClientConfig.() -> Unit = {},
-        ): Client {
-            val normalizedUrl = normalizeScheme(url)
-            val config = ClientConfig().apply(init)
-            validateConfig(config)
-            val httpClient =
-                HttpClient(CIO) {
-                    install(WebSockets)
-                }
+            /**
+             * Connect to a wspulse WebSocket server.
+             *
+             * The initial dial is always fatal: if the handshake fails, the exception is propagated to
+             * the caller regardless of whether [ClientConfig.autoReconnect] is configured. No callbacks
+             * fire and no [Client] is returned to the caller. Auto-reconnect only activates after a
+             * successful initial connection subsequently drops.
+             *
+             * @param url WebSocket or HTTP URL (e.g. `wss://host/ws`).
+             * ```
+             *             `http://` and `https://` schemes are auto-converted
+             *             to `ws://` and `wss://` respectively.
+             * @param init
+             * ```
+             * DSL block to configure the client.
+             * @return A [Client] whose initial WebSocket handshake has completed
+             * ```
+             *         successfully. The underlying transport is connected on a
+             *         best-effort basis and may transition to reconnecting or closed
+             *         state according to the configured lifecycle.
+             * ```
+             */
+            suspend fun connect(
+                url: String,
+                init: ClientConfig.() -> Unit = {},
+            ): Client {
+                val normalizedUrl = normalizeScheme(url)
+                val config = ClientConfig().apply(init)
+                validateConfig(config)
+                val httpClient = HttpClient(CIO) { install(WebSockets) }
 
-            val dialer =
-                Dialer { dialUrl, dialHeaders ->
-                    val session =
-                        httpClient.webSocketSession(dialUrl) {
-                            headers {
-                                dialHeaders.forEach { (k, v) -> append(k, v) }
+                val dialer =
+                    Dialer { dialUrl, dialHeaders ->
+                        val session =
+                            httpClient.webSocketSession(dialUrl) {
+                                headers { dialHeaders.forEach { (k, v) -> append(k, v) } }
                             }
+                        RealTransport(session, CoroutineScope(session.coroutineContext))
+                    }
+
+                return connectInternal(
+                    normalizedUrl,
+                    config,
+                    dialer,
+                    onShutdown = { httpClient.close() },
+                )
+            }
+
+            /**
+             * Internal connect for testing — accepts a custom [Dialer].
+             *
+             * Not part of the public API. Callers must validate config and normalize the URL before
+             * calling.
+             */
+            @JvmSynthetic
+            internal suspend fun connectInternal(
+                url: String,
+                config: ClientConfig,
+                dialer: Dialer,
+                onShutdown: () -> Unit = {},
+                dispatcher: CoroutineDispatcher = Dispatchers.IO,
+                random: Random = Random.Default,
+            ): Client {
+                val client = WspulseClient(url, config, dialer, onShutdown, dispatcher, random)
+
+                try {
+                    val transport = client.dialOnce()
+                    val dropped = client.startConnection(transport)
+                    // Monitor for transport drop -> reconnect or permanent disconnect.
+                    client.scope.launch {
+                        val cause: Exception?
+                        try {
+                            cause = dropped.await()
+                        } catch (_: CancellationException) {
+                            return@launch
                         }
-                    RealTransport(session, CoroutineScope(session.coroutineContext))
+                        client.handleTransportDrop(cause)
+                    }
+                } catch (e: Exception) {
+                    // Release resources before propagating.
+                    client.scope.coroutineContext[Job]?.cancel()
+                    client.onShutdown()
+                    throw e
                 }
 
-            return connectInternal(normalizedUrl, config, dialer, onShutdown = { httpClient.close() })
+                return client
+            }
         }
+
+        /** Scope that owns all internal coroutines. */
+        private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+        /** Bounded send channel. [send] uses [Channel.trySend] (non-blocking). */
+        private val sendChannel = Channel<ByteArray>(config.sendBufferSize)
+
+        /** Completes on permanent disconnect. */
+        private val _done = CompletableDeferred<Unit>()
+        override val done: Deferred<Unit>
+            get() = _done
+
+        /** Guards [shutdown] to fire exactly once. */
+        private val shutdownOnce = AtomicBoolean(false)
+
+        /** Whether [close] has been called. */
+        private val closed = AtomicBoolean(false)
+
+        /** Guards [handleTransportDrop] to prevent concurrent reconnect loops. */
+        private val reconnecting = AtomicBoolean(false)
 
         /**
-         * Internal connect for testing — accepts a custom [Dialer].
-         *
-         * Not part of the public API. Callers must validate config and
-         * normalize the URL before calling.
+         * Job for the current connection's coroutines (readLoop, writeLoop, pingLoop). Cancelled and
+         * replaced on each reconnect so old loops stop before new ones start.
          */
-        @JvmSynthetic
-        internal suspend fun connectInternal(
-            url: String,
-            config: ClientConfig,
-            dialer: Dialer,
-            onShutdown: () -> Unit = {},
-            dispatcher: CoroutineDispatcher = Dispatchers.IO,
-            random: Random = Random.Default,
-        ): Client {
-            val client = WspulseClient(url, config, dialer, onShutdown, dispatcher, random)
+        private var connectionJob: Job? = null
 
-            try {
-                val transport = client.dialOnce()
-                val dropped = client.startConnection(transport)
-                // Monitor for transport drop -> reconnect or permanent disconnect.
-                client.scope.launch {
-                    val cause: Exception?
-                    try {
-                        cause = dropped.await()
-                    } catch (_: CancellationException) {
-                        return@launch
-                    }
-                    client.handleTransportDrop(cause)
-                }
-            } catch (e: Exception) {
-                // Release resources before propagating.
-                client.scope.coroutineContext[Job]?.cancel()
-                client.onShutdown()
-                throw e
-            }
+        /** Current transport. Guarded by [connectionJob] lifecycle. */
+        @Volatile private var transport: Transport? = null
 
-            return client
-        }
-    }
+        // ── public API ──────────────────────────────────────────────────────────
 
-    /** Scope that owns all internal coroutines. */
-    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+        override fun send(frame: Frame) {
+            if (closed.get() || _done.isCompleted) throw ConnectionClosedException()
 
-    /** Bounded send channel. [send] uses [Channel.trySend] (non-blocking). */
-    private val sendChannel = Channel<ByteArray>(config.sendBufferSize)
+            val data = config.codec.encode(frame)
 
-    /** Completes on permanent disconnect. */
-    private val _done = CompletableDeferred<Unit>()
-    override val done: Deferred<Unit> get() = _done
-
-    /** Guards [shutdown] to fire exactly once. */
-    private val shutdownOnce = AtomicBoolean(false)
-
-    /** Whether [close] has been called. */
-    private val closed = AtomicBoolean(false)
-
-    /** Guards [handleTransportDrop] to prevent concurrent reconnect loops. */
-    private val reconnecting = AtomicBoolean(false)
-
-    /**
-     * Job for the current connection's coroutines (readLoop, writeLoop,
-     * pingLoop). Cancelled and replaced on each reconnect so old loops
-     * stop before new ones start.
-     */
-    private var connectionJob: Job? = null
-
-    /** Current transport. Guarded by [connectionJob] lifecycle. */
-    @Volatile
-    private var transport: Transport? = null
-
-    // ── public API ──────────────────────────────────────────────────────────
-
-    override fun send(frame: Frame) {
-        if (closed.get() || _done.isCompleted) throw ConnectionClosedException()
-
-        val data = config.codec.encode(frame)
-
-        val result = sendChannel.trySend(data)
-        if (result.isFailure) {
-            if (_done.isCompleted) throw ConnectionClosedException()
-            throw SendBufferFullException()
-        }
-    }
-
-    override suspend fun close() {
-        if (!closed.compareAndSet(false, true)) {
-            // Already closing/closed — just wait for completion.
-            _done.await()
-            return
-        }
-
-        logger.info("wspulse/client: closing url={}", url)
-
-        // Send WebSocket close frame (best-effort).
-        try {
-            transport?.close(TransportCloseReason.NORMAL)
-        } catch (_: Exception) {
-            // Already closed — ignore.
-        }
-
-        // Cancel the scope and wait for all child coroutines to finish.
-        scope.coroutineContext[Job]?.cancelAndJoin()
-
-        // Transition to CLOSED.
-        shutdown(null)
-    }
-
-    // ── internal: connection lifecycle ───────────────────────────────────────
-
-    /**
-     * Dial the WebSocket server once.
-     *
-     * @throws Exception on connection failure.
-     */
-    private suspend fun dialOnce(): Transport = dialer.dial(url, config.dialHeaders)
-
-    /**
-     * Start readLoop, writeLoop, and pingLoop for a new transport.
-     *
-     * Previous connection coroutines (if any) are cancelled first.
-     *
-     * @return the [CompletableDeferred] that completes when the transport drops.
-     */
-    private fun startConnection(ws: Transport): CompletableDeferred<Exception?> {
-        connectionJob?.cancel()
-        val oldTransport = transport
-        transport = ws
-
-        // Best-effort close the previous transport.
-        if (oldTransport != null) {
-            scope.launch {
-                try {
-                    oldTransport.close(TransportCloseReason.RECONNECTING)
-                } catch (_: Exception) {
-                    // already closed
-                }
+            val result = sendChannel.trySend(data)
+            if (result.isFailure) {
+                if (_done.isCompleted) throw ConnectionClosedException()
+                throw SendBufferFullException()
             }
         }
 
-        val job = Job(scope.coroutineContext[Job])
-        connectionJob = job
-        val connScope = CoroutineScope(scope.coroutineContext + job)
-
-        val dropped = CompletableDeferred<Exception?>()
-
-        connScope.launch { readLoop(ws, dropped) }
-        connScope.launch { writeLoop(ws, dropped) }
-        connScope.launch { pingLoop(ws, dropped) }
-
-        return dropped
-    }
-
-    /**
-     * Read incoming WebSocket frames, decode, and dispatch to onMessage.
-     *
-     * Completes [dropped] when the transport's incoming channel closes
-     * (transport drop).
-     */
-    private suspend fun readLoop(
-        ws: Transport,
-        dropped: CompletableDeferred<Exception?>,
-    ) {
-        var readError: Exception? = null
-        try {
-            for (wsFrame in ws.incoming) {
-                if (!scope.isActive) return
-
-                val data: ByteArray =
-                    when (wsFrame) {
-                        is TransportFrame.Text -> wsFrame.data.toByteArray(Charsets.UTF_8)
-                        is TransportFrame.Binary -> wsFrame.data
-                        is TransportFrame.Pong -> {
-                            resetPongDeadline(ws)
-                            continue
-                        }
-                        else -> continue
-                    }
-
-                // maxMessageSize enforcement.
-                if (config.maxMessageSize > 0 && data.size.toLong() > config.maxMessageSize) {
-                    logger.warn(
-                        "wspulse/client: message too large ({} > {}), closing",
-                        data.size,
-                        config.maxMessageSize,
-                    )
-                    try {
-                        ws.close(TransportCloseReason.MESSAGE_TOO_LARGE)
-                    } catch (_: Exception) {
-                        // already closing
-                    }
-                    break
-                }
-
-                val frame: Frame
-                try {
-                    frame = config.codec.decode(data)
-                } catch (e: Exception) {
-                    logger.warn("wspulse/client: decode failed, frame dropped", e)
-                    continue
-                }
-                try {
-                    config.onMessage(frame)
-                } catch (e: Exception) {
-                    logger.warn("wspulse/client: onMessage callback threw", e)
-                }
-            }
-        } catch (_: ClosedReceiveChannelException) {
-            // Normal: session closed.
-        } catch (_: CancellationException) {
-            throw CancellationException("readLoop cancelled")
-        } catch (e: Exception) {
-            readError = e
-            logger.debug("wspulse/client: readLoop error", e)
-        } finally {
-            dropped.complete(readError)
-        }
-    }
-
-    /**
-     * Consume the send channel and write to the WebSocket.
-     *
-     * Each write is wrapped in [withTimeout] using [ClientConfig.writeWait].
-     */
-    private suspend fun writeLoop(
-        ws: Transport,
-        dropped: CompletableDeferred<Exception?>,
-    ) {
-        try {
-            for (data in sendChannel) {
-                if (!scope.isActive) return
-
-                val wsFrame =
-                    when (config.codec.frameType) {
-                        FrameType.TEXT -> TransportFrame.Text(String(data, Charsets.UTF_8))
-                        FrameType.BINARY -> TransportFrame.Binary(data)
-                    }
-
-                try {
-                    withTimeout(config.writeWait) {
-                        ws.send(wsFrame)
-                    }
-                } catch (e: Exception) {
-                    if (e is CancellationException && !scope.isActive) throw e
-                    logger.warn("wspulse/client: write failed", e)
-                    dropped.complete(e)
-                    try {
-                        ws.close(TransportCloseReason.WRITE_ERROR)
-                    } catch (_: Exception) {
-                        // already closing
-                    }
-                    return
-                }
-            }
-        } catch (_: CancellationException) {
-            // Scope cancelled — normal shutdown.
-        }
-    }
-
-    // ── internal: heartbeat ─────────────────────────────────────────────────
-
-    /** Job for the current pong deadline timer. Reset on each Pong received. */
-    @Volatile
-    private var pongDeadlineJob: Job? = null
-
-    /**
-     * Send WebSocket Ping frames at [HeartbeatConfig.pingPeriod] intervals.
-     */
-    private suspend fun pingLoop(
-        ws: Transport,
-        dropped: CompletableDeferred<Exception?>,
-    ) {
-        val pingPeriod = config.heartbeat.pingPeriod
-
-        // Send initial ping and start pong deadline.
-        try {
-            ws.send(TransportFrame.Ping(ByteArray(0)))
-            resetPongDeadline(ws)
-        } catch (e: Exception) {
-            dropped.complete(e)
-            return
-        }
-
-        try {
-            while (scope.isActive) {
-                delay(pingPeriod)
-                ws.send(TransportFrame.Ping(ByteArray(0)))
-            }
-        } catch (_: CancellationException) {
-            // Normal shutdown.
-        } catch (e: Exception) {
-            dropped.complete(e)
-            logger.debug("wspulse/client: pingLoop error", e)
-        }
-    }
-
-    /**
-     * Reset the pong deadline timer. Called when a Pong frame is received.
-     *
-     * If the timer fires (no Pong within [HeartbeatConfig.pongWait]), the
-     * transport is closed, which triggers a transport drop.
-     */
-    private fun resetPongDeadline(ws: Transport) {
-        pongDeadlineJob?.cancel()
-        pongDeadlineJob =
-            scope.launch {
-                delay(config.heartbeat.pongWait)
-                logger.warn("wspulse/client: pong timeout, closing connection")
-                try {
-                    ws.close(TransportCloseReason.PONG_TIMEOUT)
-                } catch (_: Exception) {
-                    // already closing
-                }
-            }
-    }
-
-    // ── internal: reconnect ─────────────────────────────────────────────────
-
-    /**
-     * Handle an unexpected transport drop.
-     *
-     * If auto-reconnect is enabled, starts the reconnect loop.
-     * Otherwise, transitions to CLOSED immediately.
-     */
-    private fun handleTransportDrop(cause: Exception?) {
-        if (closed.get()) return
-        if (!reconnecting.compareAndSet(false, true)) return
-
-        // Cancel current connection coroutines.
-        connectionJob?.cancel()
-        pongDeadlineJob?.cancel()
-
-        val err = cause ?: Exception("wspulse: transport closed unexpectedly")
-        config.onTransportDrop(err)
-
-        if (config.autoReconnect != null) {
-            scope.launch { reconnectLoop() }
-        } else {
-            shutdown(ConnectionLostException(err))
-        }
-    }
-
-    /**
-     * Reconnect loop with exponential backoff.
-     *
-     * Persistent loop — after a successful reconnect, waits for the new
-     * connection to drop before retrying. This eliminates the race window
-     * where a drop between [startConnection] and `reconnecting.set(false)`
-     * could be silently ignored.
-     *
-     * Stops when:
-     * - Max retries exhausted → CLOSED with [RetriesExhaustedException].
-     * - [close] called → CLOSED with `null`.
-     */
-    private suspend fun reconnectLoop() {
-        val rc = config.autoReconnect ?: return
-        var attempt = 0
-
-        while (scope.isActive && !closed.get()) {
-            // Check max retries.
-            if (rc.maxRetries > 0 && attempt >= rc.maxRetries) {
-                shutdown(RetriesExhaustedException(attempt))
+        override suspend fun close() {
+            if (!closed.compareAndSet(false, true)) {
+                // Already closing/closed — just wait for completion.
+                _done.await()
                 return
             }
 
-            // Backoff delay.
-            val delayDuration = backoff(attempt, rc.baseDelay, rc.maxDelay, random)
-            logger.debug(
-                "wspulse/client: backoff attempt={} delay={}",
-                attempt,
-                delayDuration,
-            )
+            logger.info("wspulse/client: closing url={}", url)
+
+            // Send WebSocket close frame (best-effort).
             try {
-                delay(delayDuration)
-            } catch (_: CancellationException) {
-                return // close() was called.
+                transport?.close(TransportCloseReason.NORMAL)
+            } catch (_: Exception) {
+                // Already closed — ignore.
             }
 
-            if (closed.get()) return
+            // Cancel the scope and wait for all child coroutines to finish.
+            scope.coroutineContext[Job]?.cancelAndJoin()
 
-            // Attempt to dial.
-            try {
-                val newTransport = dialOnce()
+            // Transition to CLOSED.
+            shutdown(null)
+        }
 
-                // Check if close() was called during dial.
-                if (closed.get()) {
+        // ── internal: connection lifecycle ───────────────────────────────────────
+
+        /**
+         * Dial the WebSocket server once.
+         *
+         * @throws Exception on connection failure.
+         */
+        private suspend fun dialOnce(): Transport = dialer.dial(url, config.dialHeaders)
+
+        /**
+         * Start readLoop, writeLoop, and pingLoop for a new transport.
+         *
+         * Previous connection coroutines (if any) are cancelled first.
+         *
+         * @return the [CompletableDeferred] that completes when the transport drops.
+         */
+        private fun startConnection(ws: Transport): CompletableDeferred<Exception?> {
+            connectionJob?.cancel()
+            val oldTransport = transport
+            transport = ws
+
+            // Best-effort close the previous transport.
+            if (oldTransport != null) {
+                scope.launch {
                     try {
-                        newTransport.close(TransportCloseReason.NORMAL)
+                        oldTransport.close(TransportCloseReason.RECONNECTING)
                     } catch (_: Exception) {
-                        // ignore
+                        // already closed
                     }
+                }
+            }
+
+            val job = Job(scope.coroutineContext[Job])
+            connectionJob = job
+            val connScope = CoroutineScope(scope.coroutineContext + job)
+
+            val dropped = CompletableDeferred<Exception?>()
+
+            connScope.launch { readLoop(ws, dropped) }
+            connScope.launch { writeLoop(ws, dropped) }
+            connScope.launch { pingLoop(ws, dropped) }
+
+            return dropped
+        }
+
+        /**
+         * Read incoming WebSocket frames, decode, and dispatch to onMessage.
+         *
+         * Completes [dropped] when the transport's incoming channel closes (transport drop).
+         */
+        private suspend fun readLoop(
+            ws: Transport,
+            dropped: CompletableDeferred<Exception?>,
+        ) {
+            var readError: Exception? = null
+            try {
+                for (wsFrame in ws.incoming) {
+                    if (!scope.isActive) return
+
+                    val data: ByteArray =
+                        when (wsFrame) {
+                            is TransportFrame.Text -> wsFrame.data.toByteArray(Charsets.UTF_8)
+                            is TransportFrame.Binary -> wsFrame.data
+                            is TransportFrame.Pong -> {
+                                resetPongDeadline(ws)
+                                continue
+                            }
+                            else -> continue
+                        }
+
+                    // maxMessageSize enforcement.
+                    if (config.maxMessageSize > 0 && data.size.toLong() > config.maxMessageSize) {
+                        logger.warn(
+                            "wspulse/client: message too large ({} > {}), closing",
+                            data.size,
+                            config.maxMessageSize,
+                        )
+                        try {
+                            ws.close(TransportCloseReason.MESSAGE_TOO_LARGE)
+                        } catch (_: Exception) {
+                            // already closing
+                        }
+                        break
+                    }
+
+                    val frame: Frame
+                    try {
+                        frame = config.codec.decode(data)
+                    } catch (e: Exception) {
+                        logger.warn("wspulse/client: decode failed, frame dropped", e)
+                        continue
+                    }
+                    try {
+                        config.onMessage(frame)
+                    } catch (e: Exception) {
+                        logger.warn("wspulse/client: onMessage callback threw", e)
+                    }
+                }
+            } catch (_: ClosedReceiveChannelException) {
+                // Normal: session closed.
+            } catch (_: CancellationException) {
+                throw CancellationException("readLoop cancelled")
+            } catch (e: Exception) {
+                readError = e
+                logger.debug("wspulse/client: readLoop error", e)
+            } finally {
+                dropped.complete(readError)
+            }
+        }
+
+        /**
+         * Consume the send channel and write to the WebSocket.
+         *
+         * Each write is wrapped in [withTimeout] using [ClientConfig.writeWait].
+         */
+        private suspend fun writeLoop(
+            ws: Transport,
+            dropped: CompletableDeferred<Exception?>,
+        ) {
+            try {
+                for (data in sendChannel) {
+                    if (!scope.isActive) return
+
+                    val wsFrame =
+                        when (config.codec.frameType) {
+                            FrameType.TEXT -> TransportFrame.Text(String(data, Charsets.UTF_8))
+                            FrameType.BINARY -> TransportFrame.Binary(data)
+                        }
+
+                    try {
+                        withTimeout(config.writeWait) { ws.send(wsFrame) }
+                    } catch (e: Exception) {
+                        if (e is CancellationException && !scope.isActive) throw e
+                        logger.warn("wspulse/client: write failed", e)
+                        dropped.complete(e)
+                        try {
+                            ws.close(TransportCloseReason.WRITE_ERROR)
+                        } catch (_: Exception) {
+                            // already closing
+                        }
+                        return
+                    }
+                }
+            } catch (_: CancellationException) {
+                // Scope cancelled — normal shutdown.
+            }
+        }
+
+        // ── internal: heartbeat ─────────────────────────────────────────────────
+
+        /** Job for the current pong deadline timer. Reset on each Pong received. */
+        @Volatile private var pongDeadlineJob: Job? = null
+
+        /** Send WebSocket Ping frames at [HeartbeatConfig.pingPeriod] intervals. */
+        private suspend fun pingLoop(
+            ws: Transport,
+            dropped: CompletableDeferred<Exception?>,
+        ) {
+            val pingPeriod = config.heartbeat.pingPeriod
+
+            // Send initial ping and start pong deadline.
+            try {
+                ws.send(TransportFrame.Ping(ByteArray(0)))
+                resetPongDeadline(ws)
+            } catch (e: Exception) {
+                dropped.complete(e)
+                return
+            }
+
+            try {
+                while (scope.isActive) {
+                    delay(pingPeriod)
+                    ws.send(TransportFrame.Ping(ByteArray(0)))
+                }
+            } catch (_: CancellationException) {
+                // Normal shutdown.
+            } catch (e: Exception) {
+                dropped.complete(e)
+                logger.debug("wspulse/client: pingLoop error", e)
+            }
+        }
+
+        /**
+         * Reset the pong deadline timer. Called when a Pong frame is received.
+         *
+         * If the timer fires (no Pong within [HeartbeatConfig.pongWait]), the transport is closed,
+         * which triggers a transport drop.
+         */
+        private fun resetPongDeadline(ws: Transport) {
+            pongDeadlineJob?.cancel()
+            pongDeadlineJob =
+                scope.launch {
+                    delay(config.heartbeat.pongWait)
+                    logger.warn("wspulse/client: pong timeout, closing connection")
+                    try {
+                        ws.close(TransportCloseReason.PONG_TIMEOUT)
+                    } catch (_: Exception) {
+                        // already closing
+                    }
+                }
+        }
+
+        // ── internal: reconnect ─────────────────────────────────────────────────
+
+        /**
+         * Handle an unexpected transport drop.
+         *
+         * If auto-reconnect is enabled, starts the reconnect loop. Otherwise, transitions to CLOSED
+         * immediately.
+         */
+        private fun handleTransportDrop(cause: Exception?) {
+            if (closed.get()) return
+            if (!reconnecting.compareAndSet(false, true)) return
+
+            // Cancel current connection coroutines.
+            connectionJob?.cancel()
+            pongDeadlineJob?.cancel()
+
+            val err = cause ?: Exception("wspulse: transport closed unexpectedly")
+            config.onTransportDrop(err)
+
+            if (config.autoReconnect != null) {
+                scope.launch { reconnectLoop() }
+            } else {
+                shutdown(ConnectionLostException(err))
+            }
+        }
+
+        /**
+         * Reconnect loop with exponential backoff.
+         *
+         * Persistent loop — after a successful reconnect, waits for the new connection to drop before
+         * retrying. This eliminates the race window where a drop between [startConnection] and
+         * `reconnecting.set(false)` could be silently ignored.
+         *
+         * Stops when:
+         * - Max retries exhausted → CLOSED with [RetriesExhaustedException].
+         * - [close] called → CLOSED with `null`.
+         */
+        private suspend fun reconnectLoop() {
+            val rc = config.autoReconnect ?: return
+            var attempt = 0
+
+            while (scope.isActive && !closed.get()) {
+                // Check max retries.
+                if (rc.maxRetries > 0 && attempt >= rc.maxRetries) {
+                    shutdown(RetriesExhaustedException(attempt))
                     return
                 }
 
-                // Start new connection loops and wait for drop.
-                val dropped = startConnection(newTransport)
-                reconnecting.set(false)
-                logger.info("wspulse/client: reconnected attempt={} url={}", attempt, url)
-
-                if (closed.get()) return
-
+                // Backoff delay.
+                val delayDuration = backoff(attempt, rc.baseDelay, rc.maxDelay, random)
+                logger.debug(
+                    "wspulse/client: backoff attempt={} delay={}",
+                    attempt,
+                    delayDuration,
+                )
                 try {
-                    config.onTransportRestore()
-                } catch (e: Exception) {
-                    logger.warn("wspulse/client: onTransportRestore callback threw", e)
-                }
-
-                // Wait for this connection to drop before looping.
-                val dropCause: Exception?
-                try {
-                    dropCause = dropped.await()
+                    delay(delayDuration)
                 } catch (_: CancellationException) {
                     return // close() was called.
                 }
+
                 if (closed.get()) return
 
-                // Prepare for next reconnect cycle.
-                reconnecting.set(true)
-                connectionJob?.cancel()
-                pongDeadlineJob?.cancel()
-                val dropErr = dropCause ?: Exception("wspulse: transport closed unexpectedly")
-                config.onTransportDrop(dropErr)
-                attempt = 0
-            } catch (e: Exception) {
-                logger.debug("wspulse/client: dial failed attempt={}", attempt, e)
-                attempt++
+                // Attempt to dial.
+                try {
+                    val newTransport = dialOnce()
+
+                    // Check if close() was called during dial.
+                    if (closed.get()) {
+                        try {
+                            newTransport.close(TransportCloseReason.NORMAL)
+                        } catch (_: Exception) {
+                            // ignore
+                        }
+                        return
+                    }
+
+                    // Start new connection loops and wait for drop.
+                    val dropped = startConnection(newTransport)
+                    reconnecting.set(false)
+                    logger.info("wspulse/client: reconnected attempt={} url={}", attempt, url)
+
+                    if (closed.get()) return
+
+                    try {
+                        config.onTransportRestore()
+                    } catch (e: Exception) {
+                        logger.warn("wspulse/client: onTransportRestore callback threw", e)
+                    }
+
+                    // Wait for this connection to drop before looping.
+                    val dropCause: Exception?
+                    try {
+                        dropCause = dropped.await()
+                    } catch (_: CancellationException) {
+                        return // close() was called.
+                    }
+                    if (closed.get()) return
+
+                    // Prepare for next reconnect cycle.
+                    reconnecting.set(true)
+                    connectionJob?.cancel()
+                    pongDeadlineJob?.cancel()
+                    val dropErr = dropCause ?: Exception("wspulse: transport closed unexpectedly")
+                    config.onTransportDrop(dropErr)
+                    attempt = 0
+                } catch (e: Exception) {
+                    logger.debug("wspulse/client: dial failed attempt={}", attempt, e)
+                    attempt++
+                }
             }
         }
-    }
 
-    // ── internal: shutdown ──────────────────────────────────────────────────
+        // ── internal: shutdown ──────────────────────────────────────────────────
 
-    /**
-     * Transition to CLOSED state. Releases all resources.
-     *
-     * @param err `null` for clean close, a [WspulseException] for abnormal
-     *   disconnect.
-     */
-    private fun shutdown(err: WspulseException?) {
-        if (!shutdownOnce.compareAndSet(false, true)) return
+        /**
+         * Transition to CLOSED state. Releases all resources.
+         *
+         * @param err `null` for clean close, a [WspulseException] for abnormal disconnect.
+         */
+        private fun shutdown(err: WspulseException?) {
+            if (!shutdownOnce.compareAndSet(false, true)) return
 
-        logger.debug("wspulse/client: shutdown err={}", err)
+            logger.debug("wspulse/client: shutdown err={}", err)
 
-        // Cancel the scope so all child coroutines exit.
-        scope.coroutineContext[Job]?.cancel()
-        connectionJob?.cancel()
-        pongDeadlineJob?.cancel()
+            // Cancel the scope so all child coroutines exit.
+            scope.coroutineContext[Job]?.cancel()
+            connectionJob?.cancel()
+            pongDeadlineJob?.cancel()
 
-        // Release external resources (e.g. CIO HttpClient).
-        try {
-            onShutdown()
-        } catch (_: Exception) {
-            // ignore
+            // Release external resources (e.g. CIO HttpClient).
+            try {
+                onShutdown()
+            } catch (_: Exception) {
+                // ignore
+            }
+
+            // On clean close while CONNECTED, fire onTransportDrop(null)
+            // before onDisconnect. Unexpected drops already fired in handleTransportDrop.
+            // When close() is called while reconnecting, do not fire again.
+            if (err == null && !reconnecting.get()) {
+                try {
+                    config.onTransportDrop(null)
+                } catch (e: Exception) {
+                    logger.warn("wspulse/client: onTransportDrop callback threw", e)
+                }
+            }
+
+            // Fire onDisconnect exactly once.
+            try {
+                config.onDisconnect(err)
+            } catch (e: Exception) {
+                logger.warn("wspulse/client: onDisconnect callback threw", e)
+            }
+
+            // Resolve done.
+            _done.complete(Unit)
         }
-
-        // Fire onDisconnect exactly once.
-        try {
-            config.onDisconnect(err)
-        } catch (e: Exception) {
-            logger.warn("wspulse/client: onDisconnect callback threw", e)
-        }
-
-        // Resolve done.
-        _done.complete(Unit)
     }
-}
 
 /**
  * [Transport] backed by a Ktor [DefaultWebSocketSession].
  *
- * This is the only class that converts between library-owned [TransportFrame]
- * and Ktor's frame types. All Ktor WebSocket frame imports are confined here
- * and in the production dialer lambda above.
+ * This is the only class that converts between library-owned [TransportFrame] and Ktor's frame
+ * types. All Ktor WebSocket frame imports are confined here and in the production dialer lambda
+ * above.
  *
  * Internal visibility — not part of the public API.
  */
@@ -669,8 +674,7 @@ internal class RealTransport(
             is TransportFrame.Binary -> session.send(WsFrame.Binary(true, frame.data))
             is TransportFrame.Ping -> session.send(WsFrame.Ping(frame.data))
             is TransportFrame.Pong -> session.send(WsFrame.Pong(frame.data))
-            is TransportFrame.Close ->
-                session.close(CloseReason(frame.code, frame.reason))
+            is TransportFrame.Close -> session.close(CloseReason(frame.code, frame.reason))
         }
     }
 
@@ -680,12 +684,10 @@ internal class RealTransport(
 /**
  * Normalize the URL scheme for WebSocket connections.
  *
- * Converts `http://` to `ws://` and `https://` to `wss://`.
- * `ws://` and `wss://` pass through unchanged.
- * Any other scheme (or missing scheme) throws [IllegalArgumentException].
+ * Converts `http://` to `ws://` and `https://` to `wss://`. `ws://` and `wss://` pass through
+ * unchanged. Any other scheme (or missing scheme) throws [IllegalArgumentException].
  *
- * Validates explicitly because Ktor's error messages for invalid
- * schemes are generic and unhelpful.
+ * Validates explicitly because Ktor's error messages for invalid schemes are generic and unhelpful.
  */
 private fun normalizeScheme(url: String): String {
     val lower = url.lowercase()
@@ -711,54 +713,36 @@ private fun normalizeScheme(url: String): String {
 /**
  * Validate [ClientConfig] values against upper bounds.
  *
- * Matches client-go's fail-fast validation. Called before any resources
- * are allocated so invalid config never leaks an [HttpClient].
+ * Matches client-go's fail-fast validation. Called before any resources are allocated so invalid
+ * config never leaks an [HttpClient].
  */
 private fun validateConfig(config: ClientConfig) {
-    require(config.sendBufferSize >= 1) {
-        "wspulse: sendBufferSize must be at least 1"
-    }
+    require(config.sendBufferSize >= 1) { "wspulse: sendBufferSize must be at least 1" }
     require(config.sendBufferSize <= MAX_SEND_BUFFER_SIZE) {
         "wspulse: sendBufferSize exceeds maximum ($MAX_SEND_BUFFER_SIZE)"
     }
 
-    require(config.maxMessageSize >= 0) {
-        "wspulse: maxMessageSize must be non-negative"
-    }
+    require(config.maxMessageSize >= 0) { "wspulse: maxMessageSize must be non-negative" }
     require(config.maxMessageSize <= MAX_MSG_SIZE_BYTES) {
         "wspulse: maxMessageSize exceeds maximum (64 MiB)"
     }
-    require(config.writeWait.isPositive()) {
-        "wspulse: writeWait must be positive"
-    }
-    require(config.writeWait <= MAX_WRITE_WAIT) {
-        "wspulse: writeWait exceeds maximum (30s)"
-    }
+    require(config.writeWait.isPositive()) { "wspulse: writeWait must be positive" }
+    require(config.writeWait <= MAX_WRITE_WAIT) { "wspulse: writeWait exceeds maximum (30s)" }
 
     val hb = config.heartbeat
-    require(hb.pingPeriod.isPositive()) {
-        "wspulse: heartbeat.pingPeriod must be positive"
-    }
+    require(hb.pingPeriod.isPositive()) { "wspulse: heartbeat.pingPeriod must be positive" }
     require(hb.pingPeriod <= MAX_PING_PERIOD) {
         "wspulse: heartbeat.pingPeriod exceeds maximum (1m)"
     }
-    require(hb.pongWait.isPositive()) {
-        "wspulse: heartbeat.pongWait must be positive"
-    }
-    require(hb.pongWait <= MAX_PONG_WAIT) {
-        "wspulse: heartbeat.pongWait exceeds maximum (2m)"
-    }
+    require(hb.pongWait.isPositive()) { "wspulse: heartbeat.pongWait must be positive" }
+    require(hb.pongWait <= MAX_PONG_WAIT) { "wspulse: heartbeat.pongWait exceeds maximum (2m)" }
     require(hb.pingPeriod < hb.pongWait) {
         "wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait"
     }
 
     config.autoReconnect?.let { rc ->
-        require(rc.maxRetries >= 0) {
-            "wspulse: autoReconnect.maxRetries must be non-negative"
-        }
-        require(rc.baseDelay.isPositive()) {
-            "wspulse: autoReconnect.baseDelay must be positive"
-        }
+        require(rc.maxRetries >= 0) { "wspulse: autoReconnect.maxRetries must be non-negative" }
+        require(rc.baseDelay.isPositive()) { "wspulse: autoReconnect.baseDelay must be positive" }
         require(rc.baseDelay <= MAX_BASE_DELAY) {
             "wspulse: autoReconnect.baseDelay exceeds maximum (1m)"
         }

--- a/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
@@ -51,6 +51,10 @@ class BasicTest {
             val received = CopyOnWriteArrayList<Frame>()
             val disconnectErr = AtomicReference<WspulseException?>(null)
             val disconnectCalled = CountDownLatch(1)
+            val transportDropFired = CountDownLatch(1)
+            val transportDropWasNull =
+                java.util.concurrent.atomic
+                    .AtomicBoolean(false)
 
             val transport = MockTransport()
             val pongResponder = transport.autoPong()
@@ -61,6 +65,10 @@ class BasicTest {
                     "ws://test",
                     clientConfig {
                         onMessage = { frame -> received.add(frame) }
+                        onTransportDrop = { err ->
+                            transportDropWasNull.set(err == null)
+                            transportDropFired.countDown()
+                        }
                         onDisconnect = { err ->
                             disconnectErr.set(err)
                             disconnectCalled.countDown()
@@ -92,7 +100,12 @@ class BasicTest {
             client.close()
             client.done.await()
 
+            assertTrue(transportDropFired.await(5, TimeUnit.SECONDS))
             assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+            assertTrue(
+                transportDropWasNull.get(),
+                "onTransportDrop should receive null on clean close",
+            )
             assertNull(disconnectErr.get())
         }
 
@@ -199,9 +212,7 @@ class BasicTest {
             }
 
             // Wait for all writes.
-            waitUntil {
-                transport.sent.count { it is TransportFrame.Text } >= count
-            }
+            waitUntil { transport.sent.count { it is TransportFrame.Text } >= count }
 
             // Echo each in order.
             val textFrames = transport.sent.filterIsInstance<TransportFrame.Text>()
@@ -241,8 +252,6 @@ class BasicTest {
     }
 
     private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil {
-            transport.sent.any { it is TransportFrame.Ping }
-        }
+        waitUntil { transport.sent.any { it is TransportFrame.Ping } }
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -267,6 +268,53 @@ class CallbackTest {
             )
         }
 
+    // ── Clean close fires onTransportDrop(null) before onDisconnect(null) ───
+
+    @Test
+    fun `clean close fires onTransportDrop null before onDisconnect null`() =
+        kotlinx.coroutines.test.runTest {
+            val order = CopyOnWriteArrayList<String>()
+            val disconnectCalled = CountDownLatch(1)
+
+            val transport = MockTransport()
+            val pongResponder = transport.autoPong()
+            val dialer = MockDialer(listOf(Result.success(transport)))
+
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onTransportDrop = { err ->
+                            assertNull(
+                                err,
+                                "onTransportDrop err should be null on clean close",
+                            )
+                            order.add("onTransportDrop")
+                        }
+                        onDisconnect = { err ->
+                            assertNull(
+                                err,
+                                "onDisconnect err should be null on clean close",
+                            )
+                            order.add("onDisconnect")
+                            disconnectCalled.countDown()
+                        }
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
+
+            waitForPing(transport)
+            pongResponder.tick()
+
+            client.close()
+            client.done.await()
+
+            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+            assertEquals(listOf("onTransportDrop", "onDisconnect"), order)
+        }
+
     // ── helpers ─────────────────────────────────────────────────────────────
 
     /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
@@ -291,8 +339,6 @@ class CallbackTest {
     }
 
     private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil {
-            transport.sent.any { it is TransportFrame.Ping }
-        }
+        waitUntil { transport.sent.any { it is TransportFrame.Ping } }
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
@@ -108,6 +108,7 @@ class LifecycleTest {
     fun `close racing with transport drop fires onDisconnect exactly once`() =
         kotlinx.coroutines.test.runTest {
             val disconnectCount = AtomicInteger(0)
+            val transportDropCount = AtomicInteger(0)
             val disconnectCalled = CountDownLatch(1)
 
             val transport = MockTransport()
@@ -118,6 +119,7 @@ class LifecycleTest {
                 WspulseClient.connectInternal(
                     "ws://test",
                     clientConfig {
+                        onTransportDrop = { transportDropCount.incrementAndGet() }
                         onDisconnect = {
                             disconnectCount.incrementAndGet()
                             disconnectCalled.countDown()
@@ -143,6 +145,7 @@ class LifecycleTest {
             // Brief window for any erroneous second call.
             testScheduler.advanceTimeBy(200)
 
+            assertEquals(1, transportDropCount.get())
             assertEquals(1, disconnectCount.get())
         }
 
@@ -170,8 +173,6 @@ class LifecycleTest {
     }
 
     private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil {
-            transport.sent.any { it is TransportFrame.Ping }
-        }
+        waitUntil { transport.sent.any { it is TransportFrame.Ping } }
     }
 }


### PR DESCRIPTION
## Summary

Change `onTransportDrop` callback signature from `(Exception) -> Unit` to `(Exception?) -> Unit`. The callback now fires unconditionally — on user-initiated close with `null`, and on unexpected drops with the transport error. Implements the contract defined in wspulse/.github#18.

## Changes

- `ClientConfig.kt`: `onTransportDrop` type updated to `(Exception?) -> Unit`; KDoc updated to document unconditional firing and null-on-close semantics
- `WspulseClient.kt` `handleTransportDrop()`: keeps synthetic error wrapper (`cause ?: Exception("wspulse: transport closed unexpectedly")`) for unexpected drops where transport provides no cause
- `WspulseClient.kt` `reconnectLoop()`: same wrapper for re-drop cycles
- `WspulseClient.kt` `shutdown()`: fires `onTransportDrop(null)` before `onDisconnect` on clean user close when not already reconnecting
- `BasicTest.kt`: scenario 1 asserts `onTransportDrop` fires with `null` on clean close
- `CallbackTest.kt`: added ordering test — `onTransportDrop(null)` before `onDisconnect(null)`
- `LifecycleTest.kt`: scenario 9 tracks `transportDropCount`, asserts exactly 1
- `CHANGELOG.md`: BREAKING change entry added

## Checklist

### Required

- [x] `make check` passes (lint → test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: major version bump discussed in linked issue
- [x] New public API: includes KDoc comments
- [x] `send()` and `close()` remain safe for concurrent use from multiple coroutines
