### PR TITLE
test: extract ComponentTestBase and remove real-time residue

### DIFF
--- a/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
@@ -1,57 +1,37 @@
 package com.wspulse.client.component
 
-import com.wspulse.client.Client
-import com.wspulse.client.ClientConfig
 import com.wspulse.client.Frame
-import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
-import org.junit.jupiter.api.AfterEach
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Basic connect/send/receive component tests for [WspulseClient].
  *
  * Uses [MockTransport] and [MockDialer] to eliminate network I/O.
  */
-class BasicTest {
-    private var testClient: Client? = null
-
-    @AfterEach
-    fun tearDown() {
-        kotlinx.coroutines.runBlocking {
-            testClient?.let {
-                it.close()
-                it.done.await()
-            }
-            testClient = null
-        }
-    }
-
+class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
     // ── Scenario 1: connect, send, receive echo, close ──────────────────────
 
     @Test
     fun `connects, sends a frame, receives echo, and closes cleanly`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val received = CopyOnWriteArrayList<Frame>()
             val disconnectErr = AtomicReference<WspulseException?>(null)
-            val disconnectCalled = CountDownLatch(1)
-            val transportDropFired = CountDownLatch(1)
+            val disconnectCalled = CompletableDeferred<Unit>()
+            val transportDropFired = CompletableDeferred<Unit>()
             val transportDropWasNull =
                 java.util.concurrent.atomic
                     .AtomicBoolean(false)
@@ -67,11 +47,11 @@ class BasicTest {
                         onMessage = { frame -> received.add(frame) }
                         onTransportDrop = { err ->
                             transportDropWasNull.set(err == null)
-                            transportDropFired.countDown()
+                            transportDropFired.complete(Unit)
                         }
                         onDisconnect = { err ->
                             disconnectErr.set(err)
-                            disconnectCalled.countDown()
+                            disconnectCalled.complete(Unit)
                         }
                     },
                     dialer,
@@ -100,8 +80,8 @@ class BasicTest {
             client.close()
             client.done.await()
 
-            assertTrue(transportDropFired.await(5, TimeUnit.SECONDS))
-            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+            transportDropFired.await()
+            disconnectCalled.await()
             assertTrue(
                 transportDropWasNull.get(),
                 "onTransportDrop should receive null on clean close",
@@ -113,7 +93,7 @@ class BasicTest {
 
     @Test
     fun `round-trips all Frame fields (event, payload)`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val received = CopyOnWriteArrayList<Frame>()
 
             val transport = MockTransport()
@@ -162,7 +142,7 @@ class BasicTest {
 
     @Test
     fun `handles server rejection gracefully`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val dialer =
                 MockDialer(
                     listOf(Result.failure(Exception("wspulse: connection rejected"))),
@@ -187,7 +167,7 @@ class BasicTest {
 
     @Test
     fun `sends multiple frames and receives them in order`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val received = CopyOnWriteArrayList<Frame>()
 
             val transport = MockTransport()
@@ -227,31 +207,4 @@ class BasicTest {
                 assertEquals(mapOf("i" to i), received[i].payload)
             }
         }
-
-    // ── helpers ─────────────────────────────────────────────────────────────
-
-    /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
-    private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-        ClientConfig().apply {
-            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-            init()
-        }
-
-    private suspend fun waitUntil(
-        timeoutMs: Long = 5_000,
-        condition: () -> Boolean,
-    ) {
-        if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
-        withContext(Dispatchers.Default) {
-            withTimeout(timeoutMs.milliseconds) {
-                while (!condition()) {
-                    kotlinx.coroutines.delay(10)
-                }
-            }
-        }
-    }
-
-    private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil { transport.sent.any { it is TransportFrame.Ping } }
-    }
 }

--- a/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
@@ -1,58 +1,38 @@
 package com.wspulse.client.component
 
 import com.wspulse.client.AutoReconnectConfig
-import com.wspulse.client.Client
-import com.wspulse.client.ClientConfig
-import com.wspulse.client.HeartbeatConfig
-import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
-import org.junit.jupiter.api.AfterEach
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertFalse
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Callback behavior component tests for [WspulseClient].
  *
  * Uses [MockTransport] and [MockDialer] to eliminate network I/O.
  */
-class CallbackTest {
-    private var testClient: Client? = null
-
-    @AfterEach
-    fun tearDown() {
-        kotlinx.coroutines.runBlocking {
-            testClient?.let {
-                it.close()
-                it.done.await()
-            }
-            testClient = null
-        }
-    }
-
+class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
     // ── Scenario 2: transport drop without reconnect ────────────────────────
 
     @Test
     fun `transport drop fires onTransportDrop and onDisconnect without reconnect`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val transportDropErr = AtomicReference<Exception?>(null)
-            val transportDropped = CountDownLatch(1)
+            val transportDropped = CompletableDeferred<Unit>()
             val disconnectErr = AtomicReference<WspulseException?>(null)
-            val disconnectCalled = CountDownLatch(1)
+            val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
             val pongResponder = transport.autoPong()
@@ -64,11 +44,11 @@ class CallbackTest {
                     clientConfig {
                         onTransportDrop = { err ->
                             transportDropErr.set(err)
-                            transportDropped.countDown()
+                            transportDropped.complete(Unit)
                         }
                         onDisconnect = { err ->
                             disconnectErr.set(err)
-                            disconnectCalled.countDown()
+                            disconnectCalled.complete(Unit)
                         }
                     },
                     dialer,
@@ -84,8 +64,8 @@ class CallbackTest {
             transport.injectClose()
 
             // Both callbacks should fire.
-            assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
-            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+            transportDropped.await()
+            disconnectCalled.await()
 
             assertTrue(
                 transportDropErr.get() != null,
@@ -101,7 +81,7 @@ class CallbackTest {
 
     @Test
     fun `onDisconnect fires exactly once on close`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val disconnectCount = AtomicInteger(0)
 
             val transport = MockTransport()
@@ -135,7 +115,7 @@ class CallbackTest {
 
     @Test
     fun `onTransportRestore does not fire on initial connect`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val restoreFired =
                 java.util.concurrent.atomic
                     .AtomicBoolean(false)
@@ -169,11 +149,11 @@ class CallbackTest {
 
     @Test
     fun `close from onTransportDrop suppresses onTransportRestore`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val restoreCount = AtomicInteger(0)
-            val disconnectCalled = CountDownLatch(1)
+            val disconnectCalled = CompletableDeferred<Unit>()
             val disconnectErr = AtomicReference<WspulseException?>(null)
-            val transportDropped = CountDownLatch(1)
+            val transportDropped = CompletableDeferred<Unit>()
 
             val transport1 = MockTransport()
             val transport2 = MockTransport()
@@ -185,11 +165,11 @@ class CallbackTest {
                 WspulseClient.connectInternal(
                     "ws://test",
                     clientConfig {
-                        onTransportDrop = { transportDropped.countDown() }
+                        onTransportDrop = { transportDropped.complete(Unit) }
                         onTransportRestore = { restoreCount.incrementAndGet() }
                         onDisconnect = { err ->
                             disconnectErr.set(err)
-                            disconnectCalled.countDown()
+                            disconnectCalled.complete(Unit)
                         }
                         autoReconnect =
                             AutoReconnectConfig(
@@ -210,10 +190,10 @@ class CallbackTest {
             transport1.injectClose()
 
             // Wait for transport drop, then close immediately.
-            assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
+            transportDropped.await()
             client.close()
 
-            assertTrue(disconnectCalled.await(10, TimeUnit.SECONDS))
+            disconnectCalled.await()
 
             // Brief window for any erroneous onTransportRestore call.
             testScheduler.advanceTimeBy(500)
@@ -230,10 +210,10 @@ class CallbackTest {
 
     @Test
     fun `transport error with exception fires onTransportDrop with that error`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val transportDropErr = AtomicReference<Exception?>(null)
-            val transportDropped = CountDownLatch(1)
-            val disconnectCalled = CountDownLatch(1)
+            val transportDropped = CompletableDeferred<Unit>()
+            val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
             val pongResponder = transport.autoPong()
@@ -245,9 +225,9 @@ class CallbackTest {
                     clientConfig {
                         onTransportDrop = { err ->
                             transportDropErr.set(err)
-                            transportDropped.countDown()
+                            transportDropped.complete(Unit)
                         }
-                        onDisconnect = { disconnectCalled.countDown() }
+                        onDisconnect = { disconnectCalled.complete(Unit) }
                     },
                     dialer,
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
@@ -260,8 +240,8 @@ class CallbackTest {
             // Inject a transport error.
             transport.injectError(Exception("connection reset"))
 
-            assertTrue(transportDropped.await(5, TimeUnit.SECONDS))
-            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+            transportDropped.await()
+            disconnectCalled.await()
             assertTrue(
                 transportDropErr.get()?.message?.contains("connection reset") == true,
                 "onTransportDrop should propagate the error",
@@ -272,9 +252,9 @@ class CallbackTest {
 
     @Test
     fun `clean close fires onTransportDrop null before onDisconnect null`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val order = CopyOnWriteArrayList<String>()
-            val disconnectCalled = CountDownLatch(1)
+            val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
             val pongResponder = transport.autoPong()
@@ -297,7 +277,7 @@ class CallbackTest {
                                 "onDisconnect err should be null on clean close",
                             )
                             order.add("onDisconnect")
-                            disconnectCalled.countDown()
+                            disconnectCalled.complete(Unit)
                         }
                     },
                     dialer,
@@ -311,7 +291,7 @@ class CallbackTest {
             client.close()
             client.done.await()
 
-            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+            disconnectCalled.await()
             assertEquals(listOf("onTransportDrop", "onDisconnect"), order)
         }
 
@@ -319,8 +299,8 @@ class CallbackTest {
 
     @Test
     fun `throwing onTransportDrop does not prevent onDisconnect from firing`() =
-        kotlinx.coroutines.test.runTest {
-            val disconnectCalled = CountDownLatch(1)
+        runTest(StandardTestDispatcher(testScheduler)) {
+            val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
             val pongResponder = transport.autoPong()
@@ -331,7 +311,7 @@ class CallbackTest {
                     "ws://test",
                     clientConfig {
                         onTransportDrop = { throw RuntimeException("callback boom") }
-                        onDisconnect = { disconnectCalled.countDown() }
+                        onDisconnect = { disconnectCalled.complete(Unit) }
                     },
                     dialer,
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
@@ -343,17 +323,14 @@ class CallbackTest {
 
             transport.injectClose()
 
-            assertTrue(
-                disconnectCalled.await(5, TimeUnit.SECONDS),
-                "onDisconnect must fire even when onTransportDrop throws",
-            )
+            disconnectCalled.await()
         }
 
     @Test
     fun `throwing onTransportDrop in reconnect loop does not abort reconnect`() =
-        kotlinx.coroutines.test.runTest {
-            val restoreCalled = CountDownLatch(1)
-            val disconnectCalled = CountDownLatch(1)
+        runTest(StandardTestDispatcher(testScheduler)) {
+            val restoreCalled = CompletableDeferred<Unit>()
+            val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport1 = MockTransport()
             val transport2 = MockTransport()
@@ -375,8 +352,8 @@ class CallbackTest {
                     "ws://test",
                     clientConfig {
                         onTransportDrop = { throw RuntimeException("callback boom") }
-                        onTransportRestore = { restoreCalled.countDown() }
-                        onDisconnect = { disconnectCalled.countDown() }
+                        onTransportRestore = { restoreCalled.complete(Unit) }
+                        onDisconnect = { disconnectCalled.complete(Unit) }
                         autoReconnect =
                             AutoReconnectConfig(
                                 maxRetries = 3,
@@ -401,10 +378,7 @@ class CallbackTest {
             waitForPing(transport2)
             pongResponder2.tick()
 
-            assertTrue(
-                restoreCalled.await(5, TimeUnit.SECONDS),
-                "onTransportRestore must fire after successful reconnect",
-            )
+            restoreCalled.await()
 
             // Drop second transport — triggers reconnectLoop onTransportDrop (line 561).
             transport2.injectClose()
@@ -413,31 +387,4 @@ class CallbackTest {
             testScheduler.advanceTimeBy(20)
             waitForPing(transport3)
         }
-
-    // ── helpers ─────────────────────────────────────────────────────────────
-
-    /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
-    private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-        ClientConfig().apply {
-            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-            init()
-        }
-
-    private suspend fun waitUntil(
-        timeoutMs: Long = 5_000,
-        condition: () -> Boolean,
-    ) {
-        if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
-        withContext(Dispatchers.Default) {
-            withTimeout(timeoutMs.milliseconds) {
-                while (!condition()) {
-                    kotlinx.coroutines.delay(10)
-                }
-            }
-        }
-    }
-
-    private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil { transport.sent.any { it is TransportFrame.Ping } }
-    }
 }

--- a/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
@@ -330,7 +330,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
     fun `throwing onTransportDrop in reconnect loop does not abort reconnect`() =
         runTest(StandardTestDispatcher(testScheduler)) {
             val restoreCalled = CompletableDeferred<Unit>()
-            val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport1 = MockTransport()
             val transport2 = MockTransport()
@@ -353,7 +352,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
                     clientConfig {
                         onTransportDrop = { throw RuntimeException("callback boom") }
                         onTransportRestore = { restoreCalled.complete(Unit) }
-                        onDisconnect = { disconnectCalled.complete(Unit) }
                         autoReconnect =
                             AutoReconnectConfig(
                                 maxRetries = 3,

--- a/src/test/kotlin/com/wspulse/client/component/ComponentTestBase.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ComponentTestBase.kt
@@ -1,0 +1,58 @@
+package com.wspulse.client.component
+
+import com.wspulse.client.Client
+import com.wspulse.client.ClientConfig
+import com.wspulse.client.HeartbeatConfig
+import com.wspulse.client.TransportFrame
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import org.junit.jupiter.api.AfterEach
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Shared base class for component tests.
+ *
+ * Provides common helpers ([clientConfig], [waitUntil], [waitForPing]) and
+ * automatic [tearDown] via `@AfterEach`. Subclasses pass their own
+ * [TestCoroutineScheduler] so that [waitUntil] advances virtual time
+ * instead of polling with real delays.
+ */
+abstract class ComponentTestBase(
+    protected val testScheduler: TestCoroutineScheduler,
+) {
+    protected var testClient: Client? = null
+
+    @AfterEach
+    fun tearDown() {
+        kotlinx.coroutines.runBlocking {
+            testClient?.let {
+                it.close()
+                it.done.await()
+            }
+            testClient = null
+        }
+    }
+
+    /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
+    protected fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
+        ClientConfig().apply {
+            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+            init()
+        }
+
+    /**
+     * Poll [condition] up to 500 times, advancing virtual time by 10 ms each
+     * iteration (5 s total). No real delays — purely scheduler-driven.
+     */
+    protected fun waitUntil(condition: () -> Boolean) {
+        repeat(500) {
+            if (condition()) return
+            testScheduler.advanceTimeBy(10)
+        }
+        error("waitUntil: condition not satisfied after 5s virtual time")
+    }
+
+    /** Wait until the transport has sent at least one Ping frame. */
+    internal fun waitForPing(transport: MockTransport) {
+        waitUntil { transport.sent.any { it is TransportFrame.Ping } }
+    }
+}

--- a/src/test/kotlin/com/wspulse/client/component/ComponentTestBase.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ComponentTestBase.kt
@@ -4,7 +4,9 @@ import com.wspulse.client.Client
 import com.wspulse.client.ClientConfig
 import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.TransportFrame
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.jupiter.api.AfterEach
 import kotlin.time.Duration.Companion.seconds
 
@@ -23,7 +25,7 @@ abstract class ComponentTestBase(
 
     @AfterEach
     fun tearDown() {
-        kotlinx.coroutines.runBlocking {
+        runBlocking(UnconfinedTestDispatcher(testScheduler)) {
             testClient?.let {
                 it.close()
                 it.done.await()

--- a/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
@@ -1,52 +1,30 @@
 package com.wspulse.client.component
 
-import com.wspulse.client.Client
-import com.wspulse.client.ClientConfig
 import com.wspulse.client.ConnectionClosedException
 import com.wspulse.client.Frame
-import com.wspulse.client.HeartbeatConfig
-import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
-import org.junit.jupiter.api.AfterEach
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Client lifecycle component tests for [WspulseClient].
  *
  * Uses [MockTransport] and [MockDialer] to eliminate network I/O.
  */
-class LifecycleTest {
-    private var testClient: Client? = null
-
-    @AfterEach
-    fun tearDown() {
-        kotlinx.coroutines.runBlocking {
-            testClient?.let {
-                it.close()
-                it.done.await()
-            }
-            testClient = null
-        }
-    }
-
+class LifecycleTest : ComponentTestBase(TestCoroutineScheduler()) {
     // ── Scenario 6: send after close ────────────────────────────────────────
 
     @Test
     fun `send after close throws ConnectionClosedException`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val transport = MockTransport()
             val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
@@ -73,7 +51,7 @@ class LifecycleTest {
 
     @Test
     fun `close is idempotent`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val disconnectCount = AtomicInteger(0)
 
             val transport = MockTransport()
@@ -106,10 +84,10 @@ class LifecycleTest {
 
     @Test
     fun `close racing with transport drop fires onDisconnect exactly once`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val disconnectCount = AtomicInteger(0)
             val transportDropCount = AtomicInteger(0)
-            val disconnectCalled = CountDownLatch(1)
+            val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
             val pongResponder = transport.autoPong()
@@ -122,7 +100,7 @@ class LifecycleTest {
                         onTransportDrop = { transportDropCount.incrementAndGet() }
                         onDisconnect = {
                             disconnectCount.incrementAndGet()
-                            disconnectCalled.countDown()
+                            disconnectCalled.complete(Unit)
                         }
                     },
                     dialer,
@@ -140,7 +118,7 @@ class LifecycleTest {
             dropJob.join()
             closeJob.join()
 
-            assertTrue(disconnectCalled.await(5, TimeUnit.SECONDS))
+            disconnectCalled.await()
 
             // Brief window for any erroneous second call.
             testScheduler.advanceTimeBy(200)
@@ -148,31 +126,4 @@ class LifecycleTest {
             assertEquals(1, transportDropCount.get())
             assertEquals(1, disconnectCount.get())
         }
-
-    // ── helpers ─────────────────────────────────────────────────────────────
-
-    /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
-    private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-        ClientConfig().apply {
-            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-            init()
-        }
-
-    private suspend fun waitUntil(
-        timeoutMs: Long = 5_000,
-        condition: () -> Boolean,
-    ) {
-        if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
-        withContext(Dispatchers.Default) {
-            withTimeout(timeoutMs.milliseconds) {
-                while (!condition()) {
-                    kotlinx.coroutines.delay(10)
-                }
-            }
-        }
-    }
-
-    private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil { transport.sent.any { it is TransportFrame.Ping } }
-    }
 }

--- a/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
@@ -1,54 +1,36 @@
 package com.wspulse.client.component
 
-import com.wspulse.client.Client
-import com.wspulse.client.ClientConfig
 import com.wspulse.client.ConnectionLostException
 import com.wspulse.client.Frame
 import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
-import org.junit.jupiter.api.AfterEach
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Miscellaneous component tests for [WspulseClient].
  *
  * Uses [MockTransport] and [MockDialer] to eliminate network I/O.
  */
-class MiscTest {
-    private var testClient: Client? = null
-
-    @AfterEach
-    fun tearDown() {
-        kotlinx.coroutines.runBlocking {
-            testClient?.let {
-                it.close()
-                it.done.await()
-            }
-            testClient = null
-        }
-    }
-
+class MiscTest : ComponentTestBase(TestCoroutineScheduler()) {
     // ── Scenario 8: concurrent sends ────────────────────────────────────────
 
     @Test
     fun `concurrent sends from multiple coroutines do not race`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val received = CopyOnWriteArrayList<Frame>()
 
             val transport = MockTransport()
@@ -88,7 +70,7 @@ class MiscTest {
             jobs.awaitAll()
 
             // Wait for all writes to appear in the transport.
-            waitUntil(timeoutMs = 10_000) {
+            waitUntil {
                 transport.sent.count { it is TransportFrame.Text } >= total
             }
 
@@ -98,7 +80,7 @@ class MiscTest {
                 transport.injectText(f.data)
             }
 
-            waitUntil(timeoutMs = 10_000) { received.size >= total }
+            waitUntil { received.size >= total }
 
             assertEquals(total, received.size)
             assertTrue(received.all { it.event == "concurrent" })
@@ -108,9 +90,9 @@ class MiscTest {
 
     @Test
     fun `pong timeout triggers ConnectionLostException`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val disconnectErr = AtomicReference<WspulseException?>(null)
-            val disconnectCalled = CountDownLatch(1)
+            val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
             // Do NOT auto-pong -- let the pong deadline fire.
@@ -122,7 +104,7 @@ class MiscTest {
                     clientConfig {
                         onDisconnect = { err ->
                             disconnectErr.set(err)
-                            disconnectCalled.countDown()
+                            disconnectCalled.complete(Unit)
                         }
                         heartbeat =
                             HeartbeatConfig(
@@ -139,40 +121,11 @@ class MiscTest {
             testScheduler.advanceTimeBy(350)
             testScheduler.runCurrent()
 
-            assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
+            assertTrue(disconnectCalled.isCompleted)
 
             assertTrue(
                 disconnectErr.get() is ConnectionLostException,
                 "expected ConnectionLostException but got: ${disconnectErr.get()}",
             )
         }
-
-    // ── helpers ─────────────────────────────────────────────────────────────
-
-    /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
-    private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-        ClientConfig().apply {
-            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-            init()
-        }
-
-    private suspend fun waitUntil(
-        timeoutMs: Long = 5_000,
-        condition: () -> Boolean,
-    ) {
-        if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
-        withContext(Dispatchers.Default) {
-            withTimeout(timeoutMs.milliseconds) {
-                while (!condition()) {
-                    kotlinx.coroutines.delay(10)
-                }
-            }
-        }
-    }
-
-    private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil {
-            transport.sent.any { it is TransportFrame.Ping }
-        }
-    }
 }

--- a/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
@@ -1,29 +1,24 @@
 package com.wspulse.client.component
 
 import com.wspulse.client.AutoReconnectConfig
-import com.wspulse.client.Client
-import com.wspulse.client.ClientConfig
 import com.wspulse.client.Dialer
 import com.wspulse.client.Frame
-import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.RetriesExhaustedException
 import com.wspulse.client.Transport
 import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.random.Random
@@ -35,27 +30,14 @@ import kotlin.time.Duration.Companion.seconds
  *
  * Uses [MockTransport] and [MockDialer] to eliminate network I/O.
  */
-class ReconnectTest {
-    private var testClient: Client? = null
-
-    @AfterEach
-    fun tearDown() {
-        kotlinx.coroutines.runBlocking {
-            testClient?.let {
-                it.close()
-                it.done.await()
-            }
-            testClient = null
-        }
-    }
-
+class ReconnectTest : ComponentTestBase(TestCoroutineScheduler()) {
     // ── Scenario 3: auto-reconnect after transport drop ─────────────────────
 
     @Test
     fun `reconnects after transport drop and resumes message flow`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val received = CopyOnWriteArrayList<Frame>()
-            val transportRestored = CountDownLatch(1)
+            val transportRestored = CompletableDeferred<Unit>()
 
             val transport1 = MockTransport()
             val transport2 = MockTransport()
@@ -69,7 +51,7 @@ class ReconnectTest {
                     "ws://test",
                     clientConfig {
                         onMessage = { frame -> received.add(frame) }
-                        onTransportRestore = { transportRestored.countDown() }
+                        onTransportRestore = { transportRestored.complete(Unit) }
                         autoReconnect =
                             AutoReconnectConfig(
                                 maxRetries = 5,
@@ -102,7 +84,7 @@ class ReconnectTest {
             pongResponder2.tick()
             testScheduler.runCurrent()
 
-            assertTrue(transportRestored.await(0, TimeUnit.MILLISECONDS))
+            assertTrue(transportRestored.isCompleted)
 
             // Send after reconnect.
             client.send(Frame(event = "after", payload = "reconnect"))
@@ -115,9 +97,9 @@ class ReconnectTest {
 
     @Test
     fun `fires RetriesExhaustedException after max retries exhausted`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val disconnectErr = AtomicReference<WspulseException?>(null)
-            val disconnectCalled = CountDownLatch(1)
+            val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
             val pongResponder = transport.autoPong()
@@ -138,7 +120,7 @@ class ReconnectTest {
                     clientConfig {
                         onDisconnect = { err ->
                             disconnectErr.set(err)
-                            disconnectCalled.countDown()
+                            disconnectCalled.complete(Unit)
                         }
                         autoReconnect =
                             AutoReconnectConfig(
@@ -164,7 +146,7 @@ class ReconnectTest {
             testScheduler.advanceTimeBy(50)
             testScheduler.runCurrent()
 
-            assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
+            assertTrue(disconnectCalled.isCompleted)
 
             assertTrue(
                 disconnectErr.get() is RetriesExhaustedException,
@@ -176,9 +158,9 @@ class ReconnectTest {
 
     @Test
     fun `close during reconnect fires onDisconnect null`() =
-        kotlinx.coroutines.test.runTest {
+        runTest(StandardTestDispatcher(testScheduler)) {
             val disconnectErr = AtomicReference<WspulseException?>(null)
-            val disconnectCalled = CountDownLatch(1)
+            val disconnectCalled = CompletableDeferred<Unit>()
             val transportDropSignal = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
@@ -208,7 +190,7 @@ class ReconnectTest {
                     clientConfig {
                         onDisconnect = { err ->
                             disconnectErr.set(err)
-                            disconnectCalled.countDown()
+                            disconnectCalled.complete(Unit)
                         }
                         onTransportDrop = { transportDropSignal.complete(Unit) }
                         autoReconnect =
@@ -240,36 +222,7 @@ class ReconnectTest {
             // Close during reconnect.
             client.close()
 
-            assertTrue(disconnectCalled.await(0, TimeUnit.MILLISECONDS))
+            assertTrue(disconnectCalled.isCompleted)
             assertNull(disconnectErr.get())
         }
-
-    // ── helpers ─────────────────────────────────────────────────────────────
-
-    /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
-    private fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-        ClientConfig().apply {
-            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-            init()
-        }
-
-    private suspend fun waitUntil(
-        timeoutMs: Long = 5_000,
-        condition: () -> Boolean,
-    ) {
-        if (condition()) return // fast path: immediately satisfied (UnconfinedTestDispatcher)
-        withContext(Dispatchers.Default) {
-            withTimeout(timeoutMs.milliseconds) {
-                while (!condition()) {
-                    kotlinx.coroutines.delay(10)
-                }
-            }
-        }
-    }
-
-    private suspend fun waitForPing(transport: MockTransport) {
-        waitUntil {
-            transport.sent.any { it is TransportFrame.Ping }
-        }
-    }
 }


### PR DESCRIPTION
## Summary

Extract shared test helpers into `ComponentTestBase` and eliminate real-time residue (`CountDownLatch`, `Dispatchers.Default` polling) from all 5 component test classes. Closes #23, relates to wspulse/.github#22.

## Changes

- Add `ComponentTestBase` abstract class with `testScheduler`, `testClient`, `tearDown()`, `clientConfig()`, `waitUntil()` (scheduler-driven, no real delays), and `waitForPing()`.
- Migrate `BasicTest`, `CallbackTest`, `LifecycleTest`, `MiscTest`, `ReconnectTest` to extend `ComponentTestBase(TestCoroutineScheduler())`.
- Replace all `CountDownLatch` usage with `CompletableDeferred<Unit>`.
- Replace all FQN `kotlinx.coroutines.test.runTest` with `runTest(StandardTestDispatcher(testScheduler))` to share the scheduler between base class and test scope.
- Remove duplicated `testClient` fields, `@AfterEach tearDown()` methods, and private helper functions from all 5 test classes.
- Remove unused imports from migrated files.
- Net diff: +154 / -339 lines (185 lines removed).

## Residual time-related patterns (all safe, non-flaky)

After the migration, a small number of time-related patterns remain. Each is bounded and will not cause flakiness:

| Pattern | Location | Why safe |
|---|---|---|
| `runBlocking` | `ComponentTestBase.tearDown()` | `@AfterEach` cannot be `suspend`; this is the required JUnit5 boundary. The client is already closed by the time teardown runs, so `done.await()` completes immediately. |
| `CompletableDeferred.await()` | All test bodies | Suspends, does not block a thread. The client uses `UnconfinedTestDispatcher`, which dispatches callbacks synchronously in the same call stack as `injectClose()` / `injectError()`. The deferred is always completed before `await()` is reached. |
| `withTimeout(1.seconds)` | `ReconnectTest` — close during reconnect | Runs inside `runTest`, so `1.seconds` is virtual time, not wall time. `transportDropSignal` is completed synchronously by `UnconfinedTestDispatcher` before the timeout fires. |
| `delay(60.seconds)` | `ReconnectTest` — slow dialer stub | Runs inside a coroutine on `UnconfinedTestDispatcher`. `client.close()` cancels it before the delay elapses; the test advances only 5 ms of virtual time. The 60-second delay is never actually waited on. |

## Checklist

### Required

- [x] `make check` passes (lint -> test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR
