### PR TITLE
chore: add CHANGELOG gate to CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,10 @@
 
 <!-- What does this PR do and why? One or two sentences. -->
 
+## Related issues <!-- optional -->
+
+<!-- Link related issues: "Closes #N" if resolved by this PR, "Relates to org/repo#N" if cross-repo. Remove this section if none. -->
+
 ## Changes
 
 <!-- List the concrete changes made. Be specific. -->

--- a/.github/workflows/changelog-gate.yml
+++ b/.github/workflows/changelog-gate.yml
@@ -1,0 +1,10 @@
+name: Changelog Gate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+
+jobs:
+  changelog-gate:
+    uses: wspulse/.github/.github/workflows/changelog-gate.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,17 +26,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: CHANGELOG gate
-        run: |
-          CHANGELOG_TOP=$(grep -m1 '## \[' CHANGELOG.md | sed 's/## \[\(.*\)\].*/\1/')
-          if [[ "${{ github.ref }}" == "refs/heads/main" || "${{ github.base_ref }}" == "main" ]]; then
-            if [ "$CHANGELOG_TOP" = "Unreleased" ]; then
-              echo "Cannot merge to main with [Unreleased] CHANGELOG — bump the version first"
-              exit 1
-            fi
-          fi
-          echo "CHANGELOG top: $CHANGELOG_TOP — OK"
-
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v5
         with:
@@ -52,6 +41,20 @@ jobs:
     if: always()
     needs: [lint-test]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: CHANGELOG gate
+        run: |
+          CHANGELOG_TOP=$(grep -m1 '## \[' CHANGELOG.md | sed 's/## \[\(.*\)\].*/\1/')
+          if [[ "${{ github.ref }}" == "refs/heads/main" || "${{ github.base_ref }}" == "main" ]]; then
+            if [ "$CHANGELOG_TOP" = "Unreleased" ]; then
+              echo "Cannot merge to main with [Unreleased] CHANGELOG — bump the version first"
+              exit 1
+            fi
+          fi
+          echo "CHANGELOG top: $CHANGELOG_TOP — OK"
+
       - name: Verify lint-test passed
         run: |
           if [[ "${{ needs.lint-test.result }}" != "success" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,17 +44,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: CHANGELOG gate
-        run: |
-          CHANGELOG_TOP=$(grep -m1 '## \[' CHANGELOG.md | sed 's/## \[\(.*\)\].*/\1/')
-          if [[ "${{ github.base_ref }}" == "main" ]]; then
-            if [ "$CHANGELOG_TOP" = "Unreleased" ]; then
-              echo "Cannot merge to main with [Unreleased] CHANGELOG — bump the version first"
-              exit 1
-            fi
-          fi
-          echo "CHANGELOG top: $CHANGELOG_TOP — OK"
-
       - name: Verify lint-test passed
         run: |
           if [[ "${{ needs.lint-test.result }}" != "success" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: CHANGELOG gate
         run: |
           CHANGELOG_TOP=$(grep -m1 '## \[' CHANGELOG.md | sed 's/## \[\(.*\)\].*/\1/')
-          if [[ "${{ github.ref }}" == "refs/heads/main" || "${{ github.base_ref }}" == "main" ]]; then
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
             if [ "$CHANGELOG_TOP" = "Unreleased" ]; then
               echo "Cannot merge to main with [Unreleased] CHANGELOG — bump the version first"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: CHANGELOG gate
+        run: |
+          CHANGELOG_TOP=$(grep -m1 '## \[' CHANGELOG.md | sed 's/## \[\(.*\)\].*/\1/')
+          if [[ "${{ github.ref }}" == "refs/heads/main" || "${{ github.base_ref }}" == "main" ]]; then
+            if [ "$CHANGELOG_TOP" = "Unreleased" ]; then
+              echo "Cannot merge to main with [Unreleased] CHANGELOG — bump the version first"
+              exit 1
+            fi
+          fi
+          echo "CHANGELOG top: $CHANGELOG_TOP — OK"
+
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v5
         with:

--- a/src/main/kotlin/com/wspulse/client/TransportFrame.kt
+++ b/src/main/kotlin/com/wspulse/client/TransportFrame.kt
@@ -81,5 +81,8 @@ internal data class TransportCloseReason(
 
         /** Message too large (1009) — received frame exceeds size limit. */
         val MESSAGE_TOO_LARGE = TransportCloseReason(1009, "message too large")
+
+        /** No status received (1005) — close frame had no status code. */
+        val NO_STATUS_RECEIVED = TransportCloseReason(1005, "")
     }
 }

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -669,7 +669,7 @@ internal class RealTransport(
                                             (reason[1].toInt() and 0xFF)
                                     ).toShort()
                                 } else {
-                                    1005.toShort()
+                                    TransportCloseReason.NO_STATUS_RECEIVED.code
                                 }
                             val msg =
                                 if (reason.size > 2) {


### PR DESCRIPTION
## Summary

Block merges to main when CHANGELOG top is \`[Unreleased]\` — prevents releasing without bumping the version first. Part of a global CI gate added across all SDKs.

## Changes

- \`.github/workflows/ci.yml\`: added \`CHANGELOG gate\` step after checkout — fails if merging to main with \`[Unreleased]\` at top of CHANGELOG

## Checklist

### Required

- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in \`commit-message-instructions.md\`
- [x] No unrelated code reformatting in this PR