### PR TITLE
refactor: flatten heartbeat API into top-level options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Changed (BREAKING)
+
+- **Heartbeat API flattened**: removed `HeartbeatConfig` data class and `heartbeat` config property. Replaced by top-level `pingInterval` (was `heartbeat.pingPeriod`) and `writeTimeout` (was `writeWait`). Pong deadline is now implicit in `writeTimeout` (was separate `heartbeat.pongWait`).
+- Renamed `writeWait` config property to `writeTimeout` for naming consistency across SDKs.
+- Validation error messages updated accordingly.
+
+### Removed
+
+- `HeartbeatConfig` data class.
+- `heartbeat.pongWait` config property (pong deadline now uses `writeTimeout`).
+
 ---
 
 ## [0.5.0] - 2026-04-04

--- a/src/main/kotlin/com/wspulse/client/ClientConfig.kt
+++ b/src/main/kotlin/com/wspulse/client/ClientConfig.kt
@@ -42,11 +42,18 @@ class ClientConfig {
      */
     var autoReconnect: AutoReconnectConfig? = null
 
-    /** Heartbeat (ping/pong) configuration. */
-    var heartbeat: HeartbeatConfig = HeartbeatConfig()
+    /**
+     * Interval between client-sent Ping frames. Must be in (0, 1m].
+     */
+    var pingInterval: Duration = 20.seconds
 
-    /** Maximum time to wait for a write to complete before treating it as a transport failure. */
-    var writeWait: Duration = 10.seconds
+    /**
+     * Deadline for a single write operation. Also used as the pong deadline — if no Pong arrives
+     * within this duration after a Ping, the connection is considered dead. Must be in (0, 30s].
+     * Setting this value below the expected server round-trip time will cause spurious heartbeat
+     * disconnects.
+     */
+    var writeTimeout: Duration = 10.seconds
 
     /**
      * Maximum incoming message size in bytes. Messages exceeding this are rejected. Set to 0 to
@@ -80,15 +87,4 @@ data class AutoReconnectConfig(
     val maxRetries: Int = 0,
     val baseDelay: Duration = 1.seconds,
     val maxDelay: Duration = 30.seconds,
-)
-
-/**
- * Heartbeat (ping/pong) timing parameters.
- *
- * @param pingPeriod Interval between outgoing pings.
- * @param pongWait Maximum time to wait for a pong reply before treating the connection as dead.
- */
-data class HeartbeatConfig(
-    val pingPeriod: Duration = 20.seconds,
-    val pongWait: Duration = 60.seconds,
 )

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -78,9 +78,8 @@ interface Client {
 
 // Configuration upper bounds — matches client-go validation ceilings.
 private const val MAX_SEND_BUFFER_SIZE = 4096
-private val MAX_PING_PERIOD = 1.minutes
-private val MAX_PONG_WAIT = 2.minutes
-private val MAX_WRITE_WAIT = 30.seconds
+private val MAX_PING_INTERVAL = 1.minutes
+private val MAX_WRITE_TIMEOUT = 30.seconds
 private const val MAX_MSG_SIZE_BYTES = 64L shl 20 // 64 MiB
 private val MAX_BASE_DELAY = 1.minutes
 private val MAX_DELAY_LIMIT = 5.minutes
@@ -367,7 +366,7 @@ class WspulseClient
         /**
          * Consume the send channel and write to the WebSocket.
          *
-         * Each write is wrapped in [withTimeout] using [ClientConfig.writeWait].
+         * Each write is wrapped in [withTimeout] using [ClientConfig.writeTimeout].
          */
         private suspend fun writeLoop(
             ws: Transport,
@@ -384,9 +383,9 @@ class WspulseClient
                         }
 
                     try {
-                        withTimeout(config.writeWait) { ws.send(wsFrame) }
+                        withTimeout(config.writeTimeout) { ws.send(wsFrame) }
                     } catch (e: TimeoutCancellationException) {
-                        // writeWait timeout — treat as write failure.
+                        // writeTimeout — treat as write failure.
                         logger.warn("wspulse/client: write failed", e)
                         dropped.complete(e)
                         try {
@@ -420,14 +419,16 @@ class WspulseClient
         /** Job for the current pong deadline timer. Reset on each Pong received. */
         @Volatile private var pongDeadlineJob: Job? = null
 
-        /** Send WebSocket Ping frames at [HeartbeatConfig.pingPeriod] intervals. */
+        /** Send WebSocket Ping frames at [ClientConfig.pingInterval] intervals. */
         private suspend fun pingLoop(
             ws: Transport,
             dropped: CompletableDeferred<Exception?>,
         ) {
-            val pingPeriod = config.heartbeat.pingPeriod
+            val pingInterval = config.pingInterval
 
-            // Send initial ping and start pong deadline.
+            // Send an initial Ping so the pong deadline is anchored to an actual round-trip.
+            // Without this, the deadline starts counting from connection open — if pingInterval
+            // > writeTimeout the deadline would expire before the first periodic Ping fires.
             try {
                 ws.send(TransportFrame.Ping(ByteArray(0)))
                 resetPongDeadline(ws)
@@ -438,7 +439,7 @@ class WspulseClient
 
             try {
                 while (scope.isActive) {
-                    delay(pingPeriod)
+                    delay(pingInterval)
                     ws.send(TransportFrame.Ping(ByteArray(0)))
                 }
             } catch (_: CancellationException) {
@@ -452,14 +453,14 @@ class WspulseClient
         /**
          * Reset the pong deadline timer. Called when a Pong frame is received.
          *
-         * If the timer fires (no Pong within [HeartbeatConfig.pongWait]), the transport is closed,
+         * If the timer fires (no Pong within [ClientConfig.writeTimeout]), the transport is closed,
          * which triggers a transport drop.
          */
         private fun resetPongDeadline(ws: Transport) {
             pongDeadlineJob?.cancel()
             pongDeadlineJob =
                 scope.launch {
-                    delay(config.heartbeat.pongWait)
+                    delay(config.writeTimeout)
                     logger.warn("wspulse/client: pong timeout, closing connection")
                     try {
                         ws.close(TransportCloseReason.PONG_TIMEOUT)
@@ -742,18 +743,13 @@ private fun validateConfig(config: ClientConfig) {
     require(config.maxMessageSize <= MAX_MSG_SIZE_BYTES) {
         "wspulse: maxMessageSize exceeds maximum (64 MiB)"
     }
-    require(config.writeWait.isPositive()) { "wspulse: writeWait must be positive" }
-    require(config.writeWait <= MAX_WRITE_WAIT) { "wspulse: writeWait exceeds maximum (30s)" }
-
-    val hb = config.heartbeat
-    require(hb.pingPeriod.isPositive()) { "wspulse: heartbeat.pingPeriod must be positive" }
-    require(hb.pingPeriod <= MAX_PING_PERIOD) {
-        "wspulse: heartbeat.pingPeriod exceeds maximum (1m)"
+    require(config.pingInterval.isPositive()) { "wspulse: pingInterval must be positive" }
+    require(config.pingInterval <= MAX_PING_INTERVAL) {
+        "wspulse: pingInterval exceeds maximum (1m)"
     }
-    require(hb.pongWait.isPositive()) { "wspulse: heartbeat.pongWait must be positive" }
-    require(hb.pongWait <= MAX_PONG_WAIT) { "wspulse: heartbeat.pongWait exceeds maximum (2m)" }
-    require(hb.pingPeriod < hb.pongWait) {
-        "wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait"
+    require(config.writeTimeout.isPositive()) { "wspulse: writeTimeout must be positive" }
+    require(config.writeTimeout <= MAX_WRITE_TIMEOUT) {
+        "wspulse: writeTimeout exceeds maximum (30s)"
     }
 
     config.autoReconnect?.let { rc ->

--- a/src/test/kotlin/com/wspulse/client/ConfigValidationTest.kt
+++ b/src/test/kotlin/com/wspulse/client/ConfigValidationTest.kt
@@ -99,71 +99,49 @@ class ConfigValidationTest {
         }
     }
 
-    // ── writeWait ───────────────────────────────────────────────────────────
+    // ── writeTimeout ──────────────────────────────────────────────────────────
 
     @Test
-    fun `zero writeWait throws`() {
+    fun `zero writeTimeout throws`() {
         assertThrows<IllegalArgumentException> {
             runBlocking {
                 WspulseClient.connect("ws://127.0.0.1:1") {
-                    writeWait = 0.seconds
+                    writeTimeout = 0.seconds
                 }
             }
         }
     }
 
     @Test
-    fun `writeWait exceeding 30s throws`() {
+    fun `writeTimeout exceeding 30s throws`() {
         assertThrows<IllegalArgumentException> {
             runBlocking {
                 WspulseClient.connect("ws://127.0.0.1:1") {
-                    writeWait = 31.seconds
+                    writeTimeout = 31.seconds
                 }
             }
         }
     }
 
-    // ── heartbeat ───────────────────────────────────────────────────────────
+    // ── pingInterval ───────────────────────────────────────────────────────
 
     @Test
-    fun `zero pingPeriod throws`() {
+    fun `zero pingInterval throws`() {
         assertThrows<IllegalArgumentException> {
             runBlocking {
                 WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat = HeartbeatConfig(pingPeriod = 0.seconds)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `pingPeriod exceeding 1m throws`() {
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat = HeartbeatConfig(pingPeriod = 61.seconds)
+                    pingInterval = 0.seconds
                 }
             }
         }
     }
 
     @Test
-    fun `zero pongWait throws`() {
+    fun `pingInterval exceeding 1m throws`() {
         assertThrows<IllegalArgumentException> {
             runBlocking {
                 WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat = HeartbeatConfig(pongWait = 0.seconds)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `pongWait exceeding 2m throws`() {
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat = HeartbeatConfig(pongWait = 2.minutes + 1.seconds)
+                    pingInterval = 61.seconds
                 }
             }
         }
@@ -233,33 +211,22 @@ class ConfigValidationTest {
     // ── negative values ─────────────────────────────────────────────────
 
     @Test
-    fun `negative writeWait throws`() {
+    fun `negative writeTimeout throws`() {
         assertThrows<IllegalArgumentException> {
             runBlocking {
                 WspulseClient.connect("ws://127.0.0.1:1") {
-                    writeWait = (-1).seconds
+                    writeTimeout = (-1).seconds
                 }
             }
         }
     }
 
     @Test
-    fun `negative pingPeriod throws`() {
+    fun `negative pingInterval throws`() {
         assertThrows<IllegalArgumentException> {
             runBlocking {
                 WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat = HeartbeatConfig(pingPeriod = (-1).seconds)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `negative pongWait throws`() {
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat = HeartbeatConfig(pongWait = (-1).seconds)
+                    pingInterval = (-1).seconds
                 }
             }
         }
@@ -282,37 +249,6 @@ class ConfigValidationTest {
             runBlocking {
                 WspulseClient.connect("ws://127.0.0.1:1") {
                     autoReconnect = AutoReconnectConfig(maxRetries = -1)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `pingPeriod greater than or equal to pongWait throws`() {
-        // Contract: pingPeriod must be strictly less than pongWait, matching client-go.
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat =
-                        HeartbeatConfig(
-                            pingPeriod = 30.seconds,
-                            pongWait = 30.seconds,
-                        )
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `pingPeriod greater than pongWait throws`() {
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat =
-                        HeartbeatConfig(
-                            pingPeriod = 60.seconds,
-                            pongWait = 20.seconds,
-                        )
                 }
             }
         }

--- a/src/test/kotlin/com/wspulse/client/WspulseClientResourceTest.kt
+++ b/src/test/kotlin/com/wspulse/client/WspulseClientResourceTest.kt
@@ -104,7 +104,8 @@ class WspulseClientResourceTest {
                     WspulseClient.connect("ws://127.0.0.1:${server.port}") {
                         onDisconnect = { disconnectLatch.countDown() }
                         // Long heartbeat to avoid interference.
-                        heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+                        pingInterval = 50.seconds
+                        writeTimeout = 30.seconds
                     }
 
                 // Give read/write/ping loops time to start.
@@ -151,7 +152,8 @@ class WspulseClientResourceTest {
                                 baseDelay = 0.1.seconds,
                                 maxDelay = 0.5.seconds,
                             )
-                        heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+                        pingInterval = 50.seconds
+                        writeTimeout = 30.seconds
                         onTransportDrop = {
                             val count = transportDropCount.incrementAndGet()
                             if (count >= 2) secondDropLatch.countDown()
@@ -228,7 +230,8 @@ class WspulseClientResourceTest {
                                 baseDelay = 0.1.seconds,
                                 maxDelay = 0.5.seconds,
                             )
-                        heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+                        pingInterval = 50.seconds
+                        writeTimeout = 30.seconds
                         onTransportRestore = { restoreFired.countDown() }
                     }
 
@@ -276,7 +279,8 @@ class WspulseClientResourceTest {
 
                 val client =
                     WspulseClient.connect("ws://127.0.0.1:${server.port}") {
-                        heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+                        pingInterval = 50.seconds
+                        writeTimeout = 30.seconds
                         onTransportRestore = { restoreFired.set(true) }
                     }
 

--- a/src/test/kotlin/com/wspulse/client/component/ComponentTestBase.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ComponentTestBase.kt
@@ -2,7 +2,6 @@ package com.wspulse.client.component
 
 import com.wspulse.client.Client
 import com.wspulse.client.ClientConfig
-import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.TransportFrame
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScheduler
@@ -37,7 +36,8 @@ abstract class ComponentTestBase(
     /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
     protected fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
         ClientConfig().apply {
-            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
+            pingInterval = 50.seconds
+            writeTimeout = 30.seconds
             init()
         }
 

--- a/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
@@ -2,7 +2,6 @@ package com.wspulse.client.component
 
 import com.wspulse.client.ConnectionLostException
 import com.wspulse.client.Frame
-import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
@@ -106,11 +105,8 @@ class MiscTest : ComponentTestBase(TestCoroutineScheduler()) {
                             disconnectErr.set(err)
                             disconnectCalled.complete(Unit)
                         }
-                        heartbeat =
-                            HeartbeatConfig(
-                                pingPeriod = 100.milliseconds,
-                                pongWait = 300.milliseconds,
-                            )
+                        pingInterval = 100.milliseconds
+                        writeTimeout = 300.milliseconds
                     },
                     dialer,
                     dispatcher = UnconfinedTestDispatcher(testScheduler),


### PR DESCRIPTION
## Summary

Flatten `HeartbeatConfig` into top-level `pingInterval` + `writeTimeout` to align with client-go v0.6.0 and the updated [interface contract](https://github.com/wspulse/.github/blob/main/doc/contracts/client/interface.md). Pong deadline is now implicit in `writeTimeout` (was separate `pongWait`).

## Related issues

- Closes #34
- Relates to wspulse/.github#32

## Changes

- Removed `HeartbeatConfig` data class and `heartbeat` config property.
- Added top-level `pingInterval` (was `heartbeat.pingPeriod`) with same default (20s) and validation (0, 1m].
- Renamed `writeWait` → `writeTimeout` with updated KDoc including RTT caveat.
- Pong deadline now uses `writeTimeout` instead of `pongWait` (default changes from 60s to 10s).
- Removed `pongWait` and `pingPeriod < pongWait` constraint validation.
- Added WHY comment on initial Ping explaining deadline anchoring.
- Updated all tests: ConfigValidationTest, WspulseClientResourceTest, ComponentTestBase, MiscTest.
- Updated CHANGELOG with BREAKING changes.

## Checklist

### Required

- [x] `make check` passes (lint → test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: v0, acceptable without major version bump