### PR TITLE
feat: remove client-side ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING**: `HeartbeatConfig` class and `ClientConfig.heartbeat` option — client-side
+  ping is removed; dead-connection detection is now handled exclusively by the Hub's
+  server-side heartbeat.
+
 ---
 
 ## [0.5.0] - 2026-04-04

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ val client = WspulseClient.connect(url) {
 | `onMessage`       | `(Frame) -> Unit`             | no-op             |
 | `onDisconnect`    | `(WspulseException?) -> Unit` | no-op             |
 | `onTransportRestore` | `() -> Unit`               | no-op             |
-| `onTransportDrop` | `(Exception) -> Unit`         | no-op             |
+| `onTransportDrop` | `(Exception?) -> Unit`        | no-op             |
 | `autoReconnect`   | `AutoReconnectConfig?`        | `null` (disabled) |
 | `writeWait`       | `Duration`                    | 10s               |
 | `maxMessageSize`  | `Long`                        | 1 MiB (1 048 576) |

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ val client = WspulseClient.connect(url) {
 | `onTransportRestore` | `() -> Unit`               | no-op             |
 | `onTransportDrop` | `(Exception) -> Unit`         | no-op             |
 | `autoReconnect`   | `AutoReconnectConfig?`        | `null` (disabled) |
-| `heartbeat`       | `HeartbeatConfig`             | 20s / 60s         |
 | `writeWait`       | `Duration`                    | 10s               |
 | `maxMessageSize`  | `Long`                        | 1 MiB (1 048 576) |
 | `dialHeaders`     | `Map<String, String>`         | `emptyMap()`      |
@@ -232,7 +231,6 @@ dependencies {
 - **Auto-reconnect** — exponential backoff with configurable max retries, base delay, and max delay. Equal jitter formula: delay ∈ `[half, full]` where full = min(base × 2^attempt, max).
 - **Transport drop callback** — `onTransportDrop` fires on every transport death, even when auto-reconnect follows. Useful for metrics and logging.
 - **Permanent disconnect callback** — `onDisconnect` fires exactly once when the client is truly done (`close()` called, retries exhausted, or connection lost without auto-reconnect).
-- **Heartbeat** — Client-side Ping/Pong keeps the connection alive and detects silently-dead servers.
 - **Max message size** — Inbound messages exceeding `maxMessageSize` are rejected with close code 1009.
 - **Backpressure** — bounded 256-frame send buffer; throws `SendBufferFullException` when full.
 - **Non-blocking send** — `send()` is a regular function (not `suspend`), safe to call from any coroutine or thread.

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -4,7 +4,7 @@
 > [`.github/doc/contracts/client/test-scenarios.md`](https://github.com/wspulse/.github/blob/main/doc/contracts/client/test-scenarios.md)
 
 Component tests use `MockTransport` and `MockDialer` to exercise the
-client's internal coroutine machinery (readLoop, writeLoop, pingLoop,
+client's internal coroutine machinery (readLoop, writeLoop,
 reconnectLoop) without any network I/O. No external dependencies
 (testserver, Go toolchain) are required.
 
@@ -20,9 +20,8 @@ reconnectLoop) without any network I/O. No external dependencies
 | 4   | Max retries exhausted, `onDisconnect(RetriesExhaustedException)`  | `fires RetriesExhaustedException after max retries exhausted`          |
 | 5   | `close()` during reconnect, loop stops, `onDisconnect(null)`      | `close during reconnect fires onDisconnect null`                       |
 | 6   | `send()` on closed client, `ConnectionClosedException`            | `send after close throws ConnectionClosedException`                    |
-| 7   | Heartbeat pong timeout, `ConnectionLostException`                 | `pong timeout triggers ConnectionLostException`                        |
-| 8   | Concurrent sends: no data race or interleaving                    | `concurrent sends from multiple coroutines do not race`                |
-| 9   | Concurrent `close()` + transport drop, onDisconnect exactly once  | `close racing with transport drop fires onDisconnect exactly once`     |
+| 7   | Concurrent sends: no data race or interleaving                    | `concurrent sends from multiple coroutines do not race`                |
+| 8   | Concurrent `close()` + transport drop, onDisconnect exactly once  | `close racing with transport drop fires onDisconnect exactly once`     |
 
 ## Additional Tests
 
@@ -40,4 +39,4 @@ reconnectLoop) without any network I/O. No external dependencies
 | `throwing onTransportDrop in reconnect loop does not abort reconnect` | onTransportDrop callback exception safety (reconnect loop path) |
 | `clean close fires onTransportDrop null before onDisconnect null`    | Clean close delivers null to both callbacks in order           |
 
-**Total: 20 component tests** (9 scenarios + 11 additional).
+**Total: 19 component tests** (8 scenarios + 11 additional).

--- a/src/main/kotlin/com/wspulse/client/ClientConfig.kt
+++ b/src/main/kotlin/com/wspulse/client/ClientConfig.kt
@@ -42,9 +42,6 @@ class ClientConfig {
      */
     var autoReconnect: AutoReconnectConfig? = null
 
-    /** Heartbeat (ping/pong) configuration. */
-    var heartbeat: HeartbeatConfig = HeartbeatConfig()
-
     /** Maximum time to wait for a write to complete before treating it as a transport failure. */
     var writeWait: Duration = 10.seconds
 
@@ -80,15 +77,4 @@ data class AutoReconnectConfig(
     val maxRetries: Int = 0,
     val baseDelay: Duration = 1.seconds,
     val maxDelay: Duration = 30.seconds,
-)
-
-/**
- * Heartbeat (ping/pong) timing parameters.
- *
- * @param pingPeriod Interval between outgoing pings.
- * @param pongWait Maximum time to wait for a pong reply before treating the connection as dead.
- */
-data class HeartbeatConfig(
-    val pingPeriod: Duration = 20.seconds,
-    val pongWait: Duration = 60.seconds,
 )

--- a/src/main/kotlin/com/wspulse/client/TransportFrame.kt
+++ b/src/main/kotlin/com/wspulse/client/TransportFrame.kt
@@ -25,28 +25,6 @@ internal sealed class TransportFrame {
         override fun toString(): String = "TransportFrame.Binary(${data.size} bytes)"
     }
 
-    /** Ping frame. */
-    class Ping(
-        val data: ByteArray,
-    ) : TransportFrame() {
-        override fun equals(other: Any?): Boolean = this === other || (other is Ping && data.contentEquals(other.data))
-
-        override fun hashCode(): Int = data.contentHashCode()
-
-        override fun toString(): String = "TransportFrame.Ping(${data.size} bytes)"
-    }
-
-    /** Pong frame (response to Ping). */
-    class Pong(
-        val data: ByteArray,
-    ) : TransportFrame() {
-        override fun equals(other: Any?): Boolean = this === other || (other is Pong && data.contentEquals(other.data))
-
-        override fun hashCode(): Int = data.contentHashCode()
-
-        override fun toString(): String = "TransportFrame.Pong(${data.size} bytes)"
-    }
-
     /** Close frame. */
     data class Close(
         val code: Short,
@@ -85,9 +63,6 @@ internal data class TransportCloseReason(
 
         /** Write error (1001) — send failed, dropping connection. */
         val WRITE_ERROR = TransportCloseReason(1001, "write error")
-
-        /** Pong timeout (1001) — server did not respond to ping in time. */
-        val PONG_TIMEOUT = TransportCloseReason(1001, "pong timeout")
 
         /** Message too large (1009) — received frame exceeds size limit. */
         val MESSAGE_TOO_LARGE = TransportCloseReason(1009, "message too large")

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -78,8 +78,6 @@ interface Client {
 
 // Configuration upper bounds — matches client-go validation ceilings.
 private const val MAX_SEND_BUFFER_SIZE = 4096
-private val MAX_PING_PERIOD = 1.minutes
-private val MAX_PONG_WAIT = 2.minutes
 private val MAX_WRITE_WAIT = 30.seconds
 private const val MAX_MSG_SIZE_BYTES = 64L shl 20 // 64 MiB
 private val MAX_BASE_DELAY = 1.minutes
@@ -90,7 +88,7 @@ private const val MAX_RETRIES_LIMIT = 32
  * Internal client implementation.
  *
  * Lifecycle states (conceptual, not exposed):
- * - CONNECTED: WebSocket session is open, readLoop/writeLoop/pingLoop running.
+ * - CONNECTED: WebSocket session is open, readLoop/writeLoop running.
  * - RECONNECTING: transport dropped, backoff + retry in progress.
  * - CLOSED: permanently disconnected, all resources released.
  */
@@ -209,7 +207,7 @@ class WspulseClient
         private val reconnecting = AtomicBoolean(false)
 
         /**
-         * Job for the current connection's coroutines (readLoop, writeLoop, pingLoop). Cancelled and
+         * Job for the current connection's coroutines (readLoop, writeLoop). Cancelled and
          * replaced on each reconnect so old loops stop before new ones start.
          */
         private var connectionJob: Job? = null
@@ -264,7 +262,7 @@ class WspulseClient
         private suspend fun dialOnce(): Transport = dialer.dial(url, config.dialHeaders)
 
         /**
-         * Start readLoop, writeLoop, and pingLoop for a new transport.
+         * Start readLoop and writeLoop for a new transport.
          *
          * Previous connection coroutines (if any) are cancelled first.
          *
@@ -294,7 +292,6 @@ class WspulseClient
 
             connScope.launch { readLoop(ws, dropped) }
             connScope.launch { writeLoop(ws, dropped) }
-            connScope.launch { pingLoop(ws, dropped) }
 
             return dropped
         }
@@ -317,10 +314,6 @@ class WspulseClient
                         when (wsFrame) {
                             is TransportFrame.Text -> wsFrame.data.toByteArray(Charsets.UTF_8)
                             is TransportFrame.Binary -> wsFrame.data
-                            is TransportFrame.Pong -> {
-                                resetPongDeadline(ws)
-                                continue
-                            }
                             else -> continue
                         }
 
@@ -415,60 +408,6 @@ class WspulseClient
             }
         }
 
-        // ── internal: heartbeat ─────────────────────────────────────────────────
-
-        /** Job for the current pong deadline timer. Reset on each Pong received. */
-        @Volatile private var pongDeadlineJob: Job? = null
-
-        /** Send WebSocket Ping frames at [HeartbeatConfig.pingPeriod] intervals. */
-        private suspend fun pingLoop(
-            ws: Transport,
-            dropped: CompletableDeferred<Exception?>,
-        ) {
-            val pingPeriod = config.heartbeat.pingPeriod
-
-            // Send initial ping and start pong deadline.
-            try {
-                ws.send(TransportFrame.Ping(ByteArray(0)))
-                resetPongDeadline(ws)
-            } catch (e: Exception) {
-                dropped.complete(e)
-                return
-            }
-
-            try {
-                while (scope.isActive) {
-                    delay(pingPeriod)
-                    ws.send(TransportFrame.Ping(ByteArray(0)))
-                }
-            } catch (_: CancellationException) {
-                // Normal shutdown.
-            } catch (e: Exception) {
-                dropped.complete(e)
-                logger.debug("wspulse/client: pingLoop error", e)
-            }
-        }
-
-        /**
-         * Reset the pong deadline timer. Called when a Pong frame is received.
-         *
-         * If the timer fires (no Pong within [HeartbeatConfig.pongWait]), the transport is closed,
-         * which triggers a transport drop.
-         */
-        private fun resetPongDeadline(ws: Transport) {
-            pongDeadlineJob?.cancel()
-            pongDeadlineJob =
-                scope.launch {
-                    delay(config.heartbeat.pongWait)
-                    logger.warn("wspulse/client: pong timeout, closing connection")
-                    try {
-                        ws.close(TransportCloseReason.PONG_TIMEOUT)
-                    } catch (_: Exception) {
-                        // already closing
-                    }
-                }
-        }
-
         // ── internal: reconnect ─────────────────────────────────────────────────
 
         /**
@@ -483,7 +422,6 @@ class WspulseClient
 
             // Cancel current connection coroutines.
             connectionJob?.cancel()
-            pongDeadlineJob?.cancel()
 
             val err = cause ?: Exception("wspulse: transport closed unexpectedly")
             try {
@@ -575,7 +513,6 @@ class WspulseClient
                     // Prepare for next reconnect cycle.
                     reconnecting.set(true)
                     connectionJob?.cancel()
-                    pongDeadlineJob?.cancel()
                     val dropErr = dropCause ?: Exception("wspulse: transport closed unexpectedly")
                     try {
                         config.onTransportDrop(dropErr)
@@ -605,7 +542,6 @@ class WspulseClient
             // Cancel the scope so all child coroutines exit.
             scope.coroutineContext[Job]?.cancel()
             connectionJob?.cancel()
-            pongDeadlineJob?.cancel()
 
             // Release external resources (e.g. CIO HttpClient).
             try {
@@ -658,8 +594,8 @@ internal class RealTransport(
                     when (frame) {
                         is WsFrame.Text -> TransportFrame.Text(frame.readText())
                         is WsFrame.Binary -> TransportFrame.Binary(frame.readBytes())
-                        is WsFrame.Ping -> TransportFrame.Ping(frame.data)
-                        is WsFrame.Pong -> TransportFrame.Pong(frame.data)
+                        is WsFrame.Ping -> continue
+                        is WsFrame.Pong -> continue
                         is WsFrame.Close -> {
                             val reason = frame.readBytes()
                             val code =
@@ -688,8 +624,6 @@ internal class RealTransport(
         when (frame) {
             is TransportFrame.Text -> session.send(frame.data)
             is TransportFrame.Binary -> session.send(WsFrame.Binary(true, frame.data))
-            is TransportFrame.Ping -> session.send(WsFrame.Ping(frame.data))
-            is TransportFrame.Pong -> session.send(WsFrame.Pong(frame.data))
             is TransportFrame.Close -> session.close(CloseReason(frame.code, frame.reason))
         }
     }
@@ -744,17 +678,6 @@ private fun validateConfig(config: ClientConfig) {
     }
     require(config.writeWait.isPositive()) { "wspulse: writeWait must be positive" }
     require(config.writeWait <= MAX_WRITE_WAIT) { "wspulse: writeWait exceeds maximum (30s)" }
-
-    val hb = config.heartbeat
-    require(hb.pingPeriod.isPositive()) { "wspulse: heartbeat.pingPeriod must be positive" }
-    require(hb.pingPeriod <= MAX_PING_PERIOD) {
-        "wspulse: heartbeat.pingPeriod exceeds maximum (1m)"
-    }
-    require(hb.pongWait.isPositive()) { "wspulse: heartbeat.pongWait must be positive" }
-    require(hb.pongWait <= MAX_PONG_WAIT) { "wspulse: heartbeat.pongWait exceeds maximum (2m)" }
-    require(hb.pingPeriod < hb.pongWait) {
-        "wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait"
-    }
 
     config.autoReconnect?.let { rc ->
         require(rc.maxRetries >= 0) { "wspulse: autoReconnect.maxRetries must be non-negative" }

--- a/src/test/kotlin/com/wspulse/client/ConfigValidationTest.kt
+++ b/src/test/kotlin/com/wspulse/client/ConfigValidationTest.kt
@@ -123,52 +123,6 @@ class ConfigValidationTest {
         }
     }
 
-    // ── heartbeat ───────────────────────────────────────────────────────────
-
-    @Test
-    fun `zero pingPeriod throws`() {
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat = HeartbeatConfig(pingPeriod = 0.seconds)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `pingPeriod exceeding 1m throws`() {
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat = HeartbeatConfig(pingPeriod = 61.seconds)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `zero pongWait throws`() {
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat = HeartbeatConfig(pongWait = 0.seconds)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `pongWait exceeding 2m throws`() {
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat = HeartbeatConfig(pongWait = 2.minutes + 1.seconds)
-                }
-            }
-        }
-    }
-
     // ── autoReconnect ───────────────────────────────────────────────────────
 
     @Test
@@ -244,28 +198,6 @@ class ConfigValidationTest {
     }
 
     @Test
-    fun `negative pingPeriod throws`() {
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat = HeartbeatConfig(pingPeriod = (-1).seconds)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `negative pongWait throws`() {
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat = HeartbeatConfig(pongWait = (-1).seconds)
-                }
-            }
-        }
-    }
-
-    @Test
     fun `negative baseDelay throws`() {
         assertThrows<IllegalArgumentException> {
             runBlocking {
@@ -282,37 +214,6 @@ class ConfigValidationTest {
             runBlocking {
                 WspulseClient.connect("ws://127.0.0.1:1") {
                     autoReconnect = AutoReconnectConfig(maxRetries = -1)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `pingPeriod greater than or equal to pongWait throws`() {
-        // Contract: pingPeriod must be strictly less than pongWait, matching client-go.
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat =
-                        HeartbeatConfig(
-                            pingPeriod = 30.seconds,
-                            pongWait = 30.seconds,
-                        )
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `pingPeriod greater than pongWait throws`() {
-        assertThrows<IllegalArgumentException> {
-            runBlocking {
-                WspulseClient.connect("ws://127.0.0.1:1") {
-                    heartbeat =
-                        HeartbeatConfig(
-                            pingPeriod = 60.seconds,
-                            pongWait = 20.seconds,
-                        )
                 }
             }
         }

--- a/src/test/kotlin/com/wspulse/client/WspulseClientResourceTest.kt
+++ b/src/test/kotlin/com/wspulse/client/WspulseClientResourceTest.kt
@@ -103,11 +103,9 @@ class WspulseClientResourceTest {
                 val client =
                     WspulseClient.connect("ws://127.0.0.1:${server.port}") {
                         onDisconnect = { disconnectLatch.countDown() }
-                        // Long heartbeat to avoid interference.
-                        heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
                     }
 
-                // Give read/write/ping loops time to start.
+                // Give read/write loops time to start.
                 delay(200)
 
                 // Server drops the connection.
@@ -151,7 +149,6 @@ class WspulseClientResourceTest {
                                 baseDelay = 0.1.seconds,
                                 maxDelay = 0.5.seconds,
                             )
-                        heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
                         onTransportDrop = {
                             val count = transportDropCount.incrementAndGet()
                             if (count >= 2) secondDropLatch.countDown()
@@ -228,7 +225,6 @@ class WspulseClientResourceTest {
                                 baseDelay = 0.1.seconds,
                                 maxDelay = 0.5.seconds,
                             )
-                        heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
                         onTransportRestore = { restoreFired.countDown() }
                     }
 
@@ -276,7 +272,6 @@ class WspulseClientResourceTest {
 
                 val client =
                     WspulseClient.connect("ws://127.0.0.1:${server.port}") {
-                        heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
                         onTransportRestore = { restoreFired.set(true) }
                     }
 

--- a/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
@@ -37,7 +37,6 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
                     .AtomicBoolean(false)
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -58,10 +57,6 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
-
-            // Respond to initial ping.
-            waitForPing(transport)
-            pongResponder.tick()
 
             // Client sends a frame.
             client.send(Frame(event = "msg", payload = mapOf("text" to "hello")))
@@ -97,7 +92,6 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
             val received = CopyOnWriteArrayList<Frame>()
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -108,9 +102,6 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
-
-            waitForPing(transport)
-            pongResponder.tick()
 
             val outbound =
                 Frame(
@@ -171,7 +162,6 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
             val received = CopyOnWriteArrayList<Frame>()
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -182,9 +172,6 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
-
-            waitForPing(transport)
-            pongResponder.tick()
 
             val count = 10
             for (i in 0 until count) {

--- a/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
@@ -300,7 +300,8 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
     @Test
     fun `throwing onTransportDrop in reconnect loop does not abort reconnect`() =
         runTest(StandardTestDispatcher(testScheduler)) {
-            val restoreCalled = CompletableDeferred<Unit>()
+            val restoreCount = AtomicInteger(0)
+            val secondRestoreCalled = CompletableDeferred<Unit>()
 
             val transport1 = MockTransport()
             val transport2 = MockTransport()
@@ -319,10 +320,14 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
                     "ws://test",
                     clientConfig {
                         onTransportDrop = { throw RuntimeException("callback boom") }
-                        onTransportRestore = { restoreCalled.complete(Unit) }
+                        onTransportRestore = {
+                            if (restoreCount.incrementAndGet() >= 2) {
+                                secondRestoreCalled.complete(Unit)
+                            }
+                        }
                         autoReconnect =
                             AutoReconnectConfig(
-                                maxRetries = 3,
+                                maxRetries = 5,
                                 baseDelay = 1.milliseconds,
                                 maxDelay = 5.milliseconds,
                             )
@@ -339,6 +344,14 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
             testScheduler.advanceTimeBy(20)
             testScheduler.runCurrent()
 
-            restoreCalled.await()
+            // Drop second transport — triggers onTransportDrop from inside reconnectLoop.
+            transport2.injectClose()
+
+            // Reconnect loop should continue (not abort) despite throwing onTransportDrop.
+            testScheduler.advanceTimeBy(20)
+            testScheduler.runCurrent()
+
+            secondRestoreCalled.await()
+            assertEquals(2, restoreCount.get())
         }
 }

--- a/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
@@ -35,7 +35,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
             val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -55,10 +54,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
-
-            // Respond to initial ping.
-            waitForPing(transport)
-            pongResponder.tick()
 
             // Simulate transport drop.
             transport.injectClose()
@@ -85,7 +80,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
             val disconnectCount = AtomicInteger(0)
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -98,9 +92,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
-
-            waitForPing(transport)
-            pongResponder.tick()
 
             client.close()
             client.done.await()
@@ -121,7 +112,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
                     .AtomicBoolean(false)
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -132,9 +122,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
-
-            waitForPing(transport)
-            pongResponder.tick()
 
             // Give time for any erroneous callback.
             testScheduler.advanceTimeBy(500)
@@ -157,7 +144,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
 
             val transport1 = MockTransport()
             val transport2 = MockTransport()
-            val pongResponder1 = transport1.autoPong()
             val dialer =
                 MockDialer(listOf(Result.success(transport1), Result.success(transport2)))
 
@@ -182,9 +168,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
-
-            waitForPing(transport1)
-            pongResponder1.tick()
 
             // Drop the transport.
             transport1.injectClose()
@@ -216,7 +199,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
             val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -233,9 +215,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
-
-            waitForPing(transport)
-            pongResponder.tick()
 
             // Inject a transport error.
             transport.injectError(Exception("connection reset"))
@@ -257,7 +236,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
             val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -285,9 +263,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
                 )
             testClient = client
 
-            waitForPing(transport)
-            pongResponder.tick()
-
             client.close()
             client.done.await()
 
@@ -303,7 +278,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
             val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -318,9 +292,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
                 )
             testClient = client
 
-            waitForPing(transport)
-            pongResponder.tick()
-
             transport.injectClose()
 
             disconnectCalled.await()
@@ -334,9 +305,6 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
             val transport1 = MockTransport()
             val transport2 = MockTransport()
             val transport3 = MockTransport()
-            val pongResponder1 = transport1.autoPong()
-            val pongResponder2 = transport2.autoPong()
-            transport3.autoPong()
             val dialer =
                 MockDialer(
                     listOf(
@@ -364,25 +332,13 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
                 )
             testClient = client
 
-            // First connection established.
-            waitForPing(transport1)
-            pongResponder1.tick()
-
-            // Drop first transport — triggers handleTransportDrop (line 474).
+            // Drop first transport — triggers handleTransportDrop.
             transport1.injectClose()
 
             // Reconnect loop should recover and connect with transport2.
             testScheduler.advanceTimeBy(20)
-            waitForPing(transport2)
-            pongResponder2.tick()
+            testScheduler.runCurrent()
 
             restoreCalled.await()
-
-            // Drop second transport — triggers reconnectLoop onTransportDrop (line 561).
-            transport2.injectClose()
-
-            // Reconnect loop should continue (not abort) despite throwing onTransportDrop.
-            testScheduler.advanceTimeBy(20)
-            waitForPing(transport3)
         }
 }

--- a/src/test/kotlin/com/wspulse/client/component/ComponentTestBase.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ComponentTestBase.kt
@@ -2,18 +2,15 @@ package com.wspulse.client.component
 
 import com.wspulse.client.Client
 import com.wspulse.client.ClientConfig
-import com.wspulse.client.HeartbeatConfig
-import com.wspulse.client.TransportFrame
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.jupiter.api.AfterEach
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Shared base class for component tests.
  *
- * Provides common helpers ([clientConfig], [waitUntil], [waitForPing]) and
+ * Provides common helpers ([clientConfig], [waitUntil]) and
  * automatic [tearDown] via `@AfterEach`. Subclasses pass their own
  * [TestCoroutineScheduler] so that [waitUntil] advances virtual time
  * instead of polling with real delays.
@@ -34,12 +31,8 @@ abstract class ComponentTestBase(
         }
     }
 
-    /** Create a [ClientConfig] with long heartbeat to prevent timeout during tests. */
-    protected fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig =
-        ClientConfig().apply {
-            heartbeat = HeartbeatConfig(pingPeriod = 50.seconds, pongWait = 60.seconds)
-            init()
-        }
+    /** Create a [ClientConfig] with default settings for tests. */
+    protected fun clientConfig(init: ClientConfig.() -> Unit = {}): ClientConfig = ClientConfig().apply(init)
 
     /**
      * Poll [condition] up to 500 times, advancing virtual time by 10 ms each
@@ -51,10 +44,5 @@ abstract class ComponentTestBase(
             testScheduler.advanceTimeBy(10)
         }
         error("waitUntil: condition not satisfied after 5s virtual time")
-    }
-
-    /** Wait until the transport has sent at least one Ping frame. */
-    internal fun waitForPing(transport: MockTransport) {
-        waitUntil { transport.sent.any { it is TransportFrame.Ping } }
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
@@ -26,7 +26,6 @@ class LifecycleTest : ComponentTestBase(TestCoroutineScheduler()) {
     fun `send after close throws ConnectionClosedException`() =
         runTest(StandardTestDispatcher(testScheduler)) {
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -37,9 +36,6 @@ class LifecycleTest : ComponentTestBase(TestCoroutineScheduler()) {
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
-
-            waitForPing(transport)
-            pongResponder.tick()
 
             client.close()
             client.done.await()
@@ -55,7 +51,6 @@ class LifecycleTest : ComponentTestBase(TestCoroutineScheduler()) {
             val disconnectCount = AtomicInteger(0)
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -68,9 +63,6 @@ class LifecycleTest : ComponentTestBase(TestCoroutineScheduler()) {
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
-
-            waitForPing(transport)
-            pongResponder.tick()
 
             // Call close multiple times concurrently.
             val jobs = (0 until 5).map { launch { client.close() } }
@@ -90,7 +82,6 @@ class LifecycleTest : ComponentTestBase(TestCoroutineScheduler()) {
             val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -107,9 +98,6 @@ class LifecycleTest : ComponentTestBase(TestCoroutineScheduler()) {
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
-
-            waitForPing(transport)
-            pongResponder.tick()
 
             // Fire close() and transport drop simultaneously.
             val dropJob = launch { transport.injectClose() }

--- a/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
@@ -1,12 +1,8 @@
 package com.wspulse.client.component
 
-import com.wspulse.client.ConnectionLostException
 import com.wspulse.client.Frame
-import com.wspulse.client.HeartbeatConfig
 import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
-import com.wspulse.client.WspulseException
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -17,8 +13,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Miscellaneous component tests for [WspulseClient].
@@ -34,7 +28,6 @@ class MiscTest : ComponentTestBase(TestCoroutineScheduler()) {
             val received = CopyOnWriteArrayList<Frame>()
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
             val dialer = MockDialer(listOf(Result.success(transport)))
 
             val client =
@@ -45,9 +38,6 @@ class MiscTest : ComponentTestBase(TestCoroutineScheduler()) {
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
-
-            waitForPing(transport)
-            pongResponder.tick()
 
             val senders = 50
             val msgsPerSender = 5
@@ -84,48 +74,5 @@ class MiscTest : ComponentTestBase(TestCoroutineScheduler()) {
 
             assertEquals(total, received.size)
             assertTrue(received.all { it.event == "concurrent" })
-        }
-
-    // ── Scenario 7: pong timeout ────────────────────────────────────────────
-
-    @Test
-    fun `pong timeout triggers ConnectionLostException`() =
-        runTest(StandardTestDispatcher(testScheduler)) {
-            val disconnectErr = AtomicReference<WspulseException?>(null)
-            val disconnectCalled = CompletableDeferred<Unit>()
-
-            val transport = MockTransport()
-            // Do NOT auto-pong -- let the pong deadline fire.
-            val dialer = MockDialer(listOf(Result.success(transport)))
-
-            val client =
-                WspulseClient.connectInternal(
-                    "ws://test",
-                    clientConfig {
-                        onDisconnect = { err ->
-                            disconnectErr.set(err)
-                            disconnectCalled.complete(Unit)
-                        }
-                        heartbeat =
-                            HeartbeatConfig(
-                                pingPeriod = 100.milliseconds,
-                                pongWait = 300.milliseconds,
-                            )
-                    },
-                    dialer,
-                    dispatcher = UnconfinedTestDispatcher(testScheduler),
-                )
-            testClient = client
-
-            // Advance past pong deadline (300 ms) then assert immediately.
-            testScheduler.advanceTimeBy(350)
-            testScheduler.runCurrent()
-
-            assertTrue(disconnectCalled.isCompleted)
-
-            assertTrue(
-                disconnectErr.get() is ConnectionLostException,
-                "expected ConnectionLostException but got: ${disconnectErr.get()}",
-            )
         }
 }

--- a/src/test/kotlin/com/wspulse/client/component/MockTransport.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MockTransport.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger
 /**
  * In-memory [Transport] for component tests.
  *
- * Incoming frames are injected via [injectText], [injectPong], etc.
+ * Incoming frames are injected via [injectText], [injectClose], etc.
  * Outgoing frames sent by the client are captured in [sent].
  */
 internal class MockTransport : Transport {
@@ -46,11 +46,6 @@ internal class MockTransport : Transport {
         incomingChannel.trySend(TransportFrame.Text(data)).getOrThrow()
     }
 
-    /** Inject a pong frame (simulates server responding to ping). */
-    fun injectPong() {
-        incomingChannel.trySend(TransportFrame.Pong(ByteArray(0))).getOrThrow()
-    }
-
     /** Close the incoming channel (simulates transport drop). */
     fun injectClose() {
         if (closedFlag.compareAndSet(false, true)) {
@@ -63,47 +58,6 @@ internal class MockTransport : Transport {
         if (closedFlag.compareAndSet(false, true)) {
             incomingChannel.close(cause)
         }
-    }
-
-    /**
-     * Auto-respond to Ping frames with Pong frames.
-     *
-     * Returns a coroutine-friendly helper. Call [PongResponder.stop] to stop
-     * responding (simulates pong timeout scenario).
-     */
-    fun autoPong(): PongResponder = PongResponder(this)
-}
-
-/**
- * Watches a [MockTransport]'s sent frames for Ping and auto-injects Pong.
- *
- * Implementation: polls [MockTransport.sent] for new Ping frames.
- * Not perfectly real-time, but sufficient for component tests where
- * exact timing is controlled.
- */
-internal class PongResponder(
-    private val transport: MockTransport,
-) {
-    private val active = AtomicBoolean(true)
-    private val lastSeen = AtomicInteger(0)
-
-    /** Check for new Ping frames and inject Pong responses. */
-    fun tick() {
-        if (!active.get()) return
-        val frames = transport.sent
-        val size = frames.size
-        for (i in lastSeen.get() until size) {
-            val frame = frames[i]
-            if (frame is TransportFrame.Ping && active.get()) {
-                transport.injectPong()
-            }
-        }
-        lastSeen.set(size)
-    }
-
-    /** Stop auto-responding to pings. */
-    fun stop() {
-        active.set(false)
     }
 }
 

--- a/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
@@ -41,8 +41,6 @@ class ReconnectTest : ComponentTestBase(TestCoroutineScheduler()) {
 
             val transport1 = MockTransport()
             val transport2 = MockTransport()
-            val pongResponder1 = transport1.autoPong()
-            val pongResponder2 = transport2.autoPong()
             val dialer =
                 MockDialer(listOf(Result.success(transport1), Result.success(transport2)))
 
@@ -65,10 +63,6 @@ class ReconnectTest : ComponentTestBase(TestCoroutineScheduler()) {
                 )
             testClient = client
 
-            // Respond to initial ping on transport1.
-            waitForPing(transport1)
-            pongResponder1.tick()
-
             // Send a frame before drop.
             client.send(Frame(event = "before", payload = "drop"))
             waitUntil { transport1.sent.any { it is TransportFrame.Text } }
@@ -78,10 +72,8 @@ class ReconnectTest : ComponentTestBase(TestCoroutineScheduler()) {
             // Drop transport1.
             transport1.injectClose()
 
-            // Advance past reconnect backoff (1 ms base, 10 ms max) and tick pong on
-            // transport2.
+            // Advance past reconnect backoff (1 ms base, 10 ms max).
             testScheduler.advanceTimeBy(20)
-            pongResponder2.tick()
             testScheduler.runCurrent()
 
             assertTrue(transportRestored.isCompleted)
@@ -102,8 +94,6 @@ class ReconnectTest : ComponentTestBase(TestCoroutineScheduler()) {
             val disconnectCalled = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-
             // Initial transport succeeds, all reconnect dials fail.
             val dialer =
                 MockDialer(
@@ -135,10 +125,6 @@ class ReconnectTest : ComponentTestBase(TestCoroutineScheduler()) {
                 )
             testClient = client
 
-            // Respond to initial ping.
-            waitForPing(transport)
-            pongResponder.tick()
-
             // Drop the transport to start reconnect loop.
             transport.injectClose()
 
@@ -164,8 +150,6 @@ class ReconnectTest : ComponentTestBase(TestCoroutineScheduler()) {
             val transportDropSignal = CompletableDeferred<Unit>()
 
             val transport = MockTransport()
-            val pongResponder = transport.autoPong()
-
             // Initial transport succeeds, reconnect dials fail (slow).
             val slowDialer =
                 object : Dialer {
@@ -205,10 +189,6 @@ class ReconnectTest : ComponentTestBase(TestCoroutineScheduler()) {
                     random = Random(42),
                 )
             testClient = client
-
-            // Respond to initial ping.
-            waitForPing(transport)
-            pongResponder.tick()
 
             // Drop to trigger reconnect.
             transport.injectClose()


### PR DESCRIPTION
## Summary

Remove redundant client-side ping mechanism. The Hub already pings every connected client; client-side ping doubles traffic and introduces a `pingInterval <= writeTimeout` configuration hazard. Dead-connection detection now relies entirely on the server-side heartbeat.

## Related issues

Closes #35
Relates to wspulse/.github#39

## Changes

- Remove exported `HeartbeatConfig` data class and `ClientConfig.heartbeat` field (breaking)
- Remove internal `pingLoop()` coroutine, `resetPongDeadline()`, `pongDeadlineJob` field
- Remove `TransportFrame.Ping`, `TransportFrame.Pong` sealed subclasses and `TransportCloseReason.PONG_TIMEOUT`
- Remove `MAX_PING_PERIOD`, `MAX_PONG_WAIT` validation constants and ~8 lines heartbeat validation in `validateConfig()`
- Simplify `RealTransport` frame conversion: Ping/Pong frames now `continue` (skipped)
- Remove `pongDeadlineJob?.cancel()` from `handleTransportDrop()`, `reconnectLoop()`, `shutdown()`
- Remove `PongResponder` class, `MockTransport.injectPong()`/`autoPong()`, `ComponentTestBase.waitForPing()`
- Delete 8 heartbeat validation tests in `ConfigValidationTest` and pong-timeout test in `MiscTest`
- Remove all `waitForPing()`/`pongResponder` usage from 5 component test classes
- Add CHANGELOG entry under `[Unreleased]`

## Checklist

### Required

- [x] `make check` passes (lint → test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: major version bump discussed in linked issue
- [x] `send()` and `close()` remain safe for concurrent use from multiple coroutines