### PR TITLE
refactor: rename Frame to Message, FrameType to WireType

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,8 +9,8 @@ wspulse/client-kt is a **WebSocket client library for Kotlin (JVM + Android)** w
 - **`WspulseClient.kt`** — `Client` interface (public API: `send`, `close`, `done`) and `WspulseClient.connect()` companion factory. Internal coroutines: `readLoop`, `writeLoop`, `reconnectLoop`, `pingLoop`. `RealTransport` wraps Ktor session.
 - **`Transport.kt`** — Internal `Transport` interface (abstracts WebSocket session) and `Dialer` functional interface (abstracts connection creation). Not public API.
 - **`ClientConfig.kt`** — Builder DSL for configuration (callbacks, reconnect, heartbeat, codec).
-- **`Codec.kt`** — `Codec` interface, `FrameType` enum, `JsonCodec` default implementation.
-- **`Frame.kt`** — `data class Frame(event, payload: Any?)`.
+- **`Codec.kt`** — `Codec` interface, `WireType` enum, `JsonCodec` default implementation.
+- **`Message.kt`** — `data class Message(event, payload: Any?)`.
 - **`Errors.kt`** — `sealed class WspulseException` hierarchy.
 - **`Backoff.kt`** — `backoff(attempt, base, max): Duration` with equal jitter.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,8 @@ making any changes.
 - `WspulseClient.kt` — `Client` interface, `WspulseClient.connect()` factory,
   `readLoop` / `writeLoop` / `reconnectLoop` / `pingLoop` coroutines
 - `ClientConfig.kt` — Builder DSL for configuration
-- `Codec.kt` — `Codec` interface, `FrameType` enum, `JsonCodec` default
-- `Frame.kt` — `data class Frame(event, payload)`
+- `Codec.kt` — `Codec` interface, `WireType` enum, `JsonCodec` default
+- `Message.kt` — `data class Message(event, payload)`
 - `Errors.kt` — `sealed class WspulseException` hierarchy
 - `Backoff.kt` — `backoff(attempt, base, max)` with equal jitter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `Frame` data class renamed to `Message` — aligns with upstream
+  wspulse/core rename. Application-layer type is now `Message`; WebSocket
+  protocol-layer `TransportFrame` is unchanged.
+- **BREAKING**: `FrameType` enum renamed to `WireType` — clarifies that it
+  describes the wire encoding format, not the application message type.
+- **BREAKING**: `Codec.frameType` property renamed to `Codec.wireType`.
+- **BREAKING**: `Client.send(frame: Frame)` renamed to `Client.send(message: Message)`.
+- **BREAKING**: `ClientConfig.onMessage` type changed from `(Frame) -> Unit` to
+  `(Message) -> Unit`.
+
 ## [0.6.0] - 2026-04-16
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Works on **JVM 17+** and **Android API 26+** via [Ktor CIO](https://ktor.io/docs
 ## Design Goals
 
 - Thin client: connect, send, receive, auto-reconnect
-- Matches server-side `Frame` wire format via JSON text frames
+- Matches server-side `Message` wire format via JSON text frames
 - Exponential backoff with configurable retries (equal jitter)
 - Transport drop vs. permanent disconnect callbacks
 - Coroutine-native with non-blocking `send()`
@@ -77,12 +77,12 @@ dependencies {
 ## Quick Start
 
 ```kotlin
-import com.wspulse.client.Frame
+import com.wspulse.client.Message
 import com.wspulse.client.WspulseClient
 
 val client = WspulseClient.connect("ws://localhost:8080/ws?room=r1&token=xyz") {
-    onMessage = { frame ->
-        println("[${frame.event}] ${frame.payload}")
+    onMessage = { msg ->
+        println("[${msg.event}] ${msg.payload}")
     }
     autoReconnect = AutoReconnectConfig(
         maxRetries = 5,
@@ -91,7 +91,7 @@ val client = WspulseClient.connect("ws://localhost:8080/ws?room=r1&token=xyz") {
     )
 }
 
-client.send(Frame(event = "msg", payload = mapOf("text" to "hello")))
+client.send(Message(event = "msg", payload = mapOf("text" to "hello")))
 
 // Suspend until permanently disconnected.
 client.done.await()
@@ -106,7 +106,7 @@ class ChatViewModel : ViewModel() {
     fun connect(url: String) {
         viewModelScope.launch {
             client = WspulseClient.connect(url) {
-                onMessage = { frame ->
+                onMessage = { msg ->
                     // Update UI state
                 }
                 autoReconnect = AutoReconnectConfig(maxRetries = 10)
@@ -125,9 +125,9 @@ class ChatViewModel : ViewModel() {
 
 ---
 
-## Frame Format
+## Message Format
 
-The default `JsonCodec` encodes frames as JSON text frames:
+The default `JsonCodec` encodes messages as JSON text frames:
 
 ```json
 {
@@ -136,20 +136,20 @@ The default `JsonCodec` encodes frames as JSON text frames:
 }
 ```
 
-The `event` field is the routing key on the server side. Set `frame.event` to match the handler registered with `r.On("chat.message", ...)` on the server. The `payload` field carries arbitrary data — the library does not inspect it.
+The `event` field is the routing key on the server side. Set `message.event` to match the handler registered with `r.On("chat.message", ...)` on the server. The `payload` field carries arbitrary data — the library does not inspect it.
 
 ```kotlin
-// Send a typed frame — server routes by "event"
-client.send(Frame(
+// Send a typed message — server routes by "event"
+client.send(Message(
     event = "chat.message",
     payload = mapOf("text" to "hello world"),
 ))
 
-// Receive typed frames
-onMessage = { frame ->
-    when (frame.event) {
-        "chat.message" -> handleMessage(frame)
-        "chat.ack"     -> handleAck(frame)
+// Receive typed messages
+onMessage = { msg ->
+    when (msg.event) {
+        "chat.message" -> handleMessage(msg)
+        "chat.ack"     -> handleAck(msg)
     }
 }
 ```
@@ -158,9 +158,9 @@ To use a custom wire format, implement the `Codec` interface:
 
 ```kotlin
 object ProtobufCodec : Codec {
-    override val frameType = FrameType.BINARY
-    override fun encode(frame: Frame): ByteArray = /* serialize */
-    override fun decode(data: ByteArray): Frame = /* deserialize */
+    override val wireType = WireType.BINARY
+    override fun encode(message: Message): ByteArray = /* serialize */
+    override fun decode(data: ByteArray): Message = /* deserialize */
 }
 
 val client = WspulseClient.connect(url) {
@@ -176,8 +176,8 @@ val client = WspulseClient.connect(url) {
 | --------------- | ---------------------------------------------------- |
 | `Client`        | Interface: `send()`, `close()`, `done`               |
 | `WspulseClient` | Implementation with `companion object { connect() }` |
-| `Frame`         | Data class: `event?`, `payload?`                     |
-| `Codec`         | Interface: `encode()`, `decode()`, `frameType`       |
+| `Message`       | Data class: `event?`, `payload?`                     |
+| `Codec`         | Interface: `encode()`, `decode()`, `wireType`        |
 | `JsonCodec`     | Default codec — JSON text frames                     |
 | `ClientConfig`  | Builder DSL for client configuration                 |
 
@@ -185,7 +185,7 @@ val client = WspulseClient.connect(url) {
 
 | Option            | Type                          | Default           |
 | ----------------- | ----------------------------- | ----------------- |
-| `onMessage`       | `(Frame) -> Unit`             | no-op             |
+| `onMessage`       | `(Message) -> Unit`           | no-op             |
 | `onDisconnect`    | `(WspulseException?) -> Unit` | no-op             |
 | `onTransportRestore` | `() -> Unit`               | no-op             |
 | `onTransportDrop` | `(Exception?) -> Unit`        | no-op             |
@@ -232,7 +232,7 @@ dependencies {
 - **Transport drop callback** — `onTransportDrop` fires on every transport death, even when auto-reconnect follows. Useful for metrics and logging.
 - **Permanent disconnect callback** — `onDisconnect` fires exactly once when the client is truly done (`close()` called, retries exhausted, or connection lost without auto-reconnect).
 - **Max message size** — Inbound messages exceeding `maxMessageSize` are rejected with close code 1009.
-- **Backpressure** — bounded 256-frame send buffer; throws `SendBufferFullException` when full.
+- **Backpressure** — bounded 256-message send buffer; throws `SendBufferFullException` when full.
 - **Non-blocking send** — `send()` is a regular function (not `suspend`), safe to call from any coroutine or thread.
 - **`done` Deferred** — completes when the client reaches CLOSED state. Await it to suspend until permanently disconnected.
 - **Idempotent close** — `close()` is safe to call multiple times from concurrent coroutines.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The default `JsonCodec` encodes messages as JSON text frames:
 }
 ```
 
-The `event` field is the routing key on the server side. Set `message.event` to match the handler registered with `r.On("chat.message", ...)` on the server. The `payload` field carries arbitrary data — the library does not inspect it.
+The `event` field is the routing key on the server side. Set `Message.event` to match the handler registered with `r.On("chat.message", ...)` on the server. The `payload` field carries arbitrary data — the library does not inspect it.
 
 ```kotlin
 // Send a typed message — server routes by "event"

--- a/src/main/kotlin/com/wspulse/client/ClientConfig.kt
+++ b/src/main/kotlin/com/wspulse/client/ClientConfig.kt
@@ -11,8 +11,8 @@ import kotlin.time.Duration.Companion.seconds
  * (e.g. [Client.close]). Implementations must not block.
  */
 class ClientConfig {
-    /** Called for every application-level frame received from the server. */
-    var onMessage: (Frame) -> Unit = {}
+    /** Called for every application-level message received from the server. */
+    var onMessage: (Message) -> Unit = {}
 
     /**
      * Called exactly once when the client permanently disconnects.
@@ -54,13 +54,13 @@ class ClientConfig {
     /** Additional HTTP headers sent during the WebSocket handshake. */
     var dialHeaders: Map<String, String> = emptyMap()
 
-    /** Codec used for frame serialisation. Defaults to [JsonCodec]. */
+    /** Codec used for message serialisation. Defaults to [JsonCodec]. */
     var codec: Codec = JsonCodec
 
     /**
-     * Capacity of the internal send buffer (number of frames).
+     * Capacity of the internal send buffer (number of messages).
      *
-     * Must be between 1 and 4096 inclusive. Larger values allow more frames to be queued during
+     * Must be between 1 and 4096 inclusive. Larger values allow more messages to be queued during
      * brief disconnections or bursty sends.
      */
     var sendBufferSize: Int = 256

--- a/src/main/kotlin/com/wspulse/client/Codec.kt
+++ b/src/main/kotlin/com/wspulse/client/Codec.kt
@@ -4,25 +4,25 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 /** Wire format used by a [Codec] implementation. */
-enum class FrameType { TEXT, BINARY }
+enum class WireType { TEXT, BINARY }
 
 /**
- * Encodes and decodes [Frame] instances for WebSocket transport.
+ * Encodes and decodes [Message] instances for WebSocket transport.
  *
  * Implementations must be stateless and safe for concurrent use.
  */
 interface Codec {
-    fun encode(frame: Frame): ByteArray
+    fun encode(message: Message): ByteArray
 
-    fun decode(data: ByteArray): Frame
+    fun decode(data: ByteArray): Message
 
-    val frameType: FrameType
+    val wireType: WireType
 }
 
 /**
  * Default JSON codec using `org.json`.
  *
- * Encodes [Frame] fields as a JSON object with keys `"event"` and `"payload"`.
+ * Encodes [Message] fields as a JSON object with keys `"event"` and `"payload"`.
  * Null fields are omitted from the output. On decode, unknown keys are
  * silently ignored.
  *
@@ -30,18 +30,18 @@ interface Codec {
  * stdlib types ([Map], [List], [String], [Number], [Boolean], `null`).
  */
 object JsonCodec : Codec {
-    override val frameType: FrameType = FrameType.TEXT
+    override val wireType: WireType = WireType.TEXT
 
-    override fun encode(frame: Frame): ByteArray {
+    override fun encode(message: Message): ByteArray {
         val obj = JSONObject()
-        frame.event?.let { obj.put("event", it) }
-        frame.payload?.let { obj.put("payload", toJson(it)) }
+        message.event?.let { obj.put("event", it) }
+        message.payload?.let { obj.put("payload", toJson(it)) }
         return obj.toString().toByteArray(Charsets.UTF_8)
     }
 
-    override fun decode(data: ByteArray): Frame {
+    override fun decode(data: ByteArray): Message {
         val obj = JSONObject(String(data, Charsets.UTF_8))
-        return Frame(
+        return Message(
             event = obj.opt("event") as? String,
             payload = obj.opt("payload")?.let { fromJson(it) },
         )

--- a/src/main/kotlin/com/wspulse/client/Errors.kt
+++ b/src/main/kotlin/com/wspulse/client/Errors.kt
@@ -13,7 +13,7 @@ sealed class WspulseException(
 /** Thrown when [Client.send] is called after the client has been closed. */
 class ConnectionClosedException : WspulseException("wspulse: connection is closed")
 
-/** Thrown when the send buffer is full and the frame cannot be enqueued. */
+/** Thrown when the send buffer is full and the message cannot be enqueued. */
 class SendBufferFullException : WspulseException("wspulse: send buffer is full")
 
 /** Thrown when the maximum number of reconnection attempts has been exhausted. */

--- a/src/main/kotlin/com/wspulse/client/Message.kt
+++ b/src/main/kotlin/com/wspulse/client/Message.kt
@@ -1,13 +1,13 @@
 package com.wspulse.client
 
 /**
- * A WebSocket application-level frame.
+ * A WebSocket application-level message.
  *
  * [payload] accepts only Kotlin stdlib types: [Map], [List], [String], [Number],
  * [Boolean], or `null`. The concrete types depend on the [Codec] used for
  * serialisation — [JsonCodec] enforces this contract.
  */
-data class Frame(
+data class Message(
     val event: String? = null,
     val payload: Any? = null,
 )

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -297,7 +297,7 @@ class WspulseClient
         }
 
         /**
-         * Read incoming WebSocket messages, decode, and dispatch to onMessage.
+         * Read incoming WebSocket frames, decode, and dispatch to onMessage.
          *
          * Completes [dropped] when the transport's incoming channel closes (transport drop).
          */

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -45,14 +45,14 @@ import io.ktor.websocket.Frame as WsFrame
  */
 interface Client {
     /**
-     * Enqueue a [Frame] for delivery to the server.
+     * Enqueue a [Message] for delivery to the server.
      *
      * Non-blocking. This function does not suspend.
      *
      * @throws ConnectionClosedException if the client is closed.
      * @throws SendBufferFullException if the internal send buffer is full.
      */
-    fun send(frame: Frame)
+    fun send(message: Message)
 
     /**
      * Permanently terminate the connection and stop any reconnect loop.
@@ -217,10 +217,10 @@ class WspulseClient
 
         // ── public API ──────────────────────────────────────────────────────────
 
-        override fun send(frame: Frame) {
+        override fun send(message: Message) {
             if (closed.get() || _done.isCompleted) throw ConnectionClosedException()
 
-            val data = config.codec.encode(frame)
+            val data = config.codec.encode(message)
 
             val result = sendChannel.trySend(data)
             if (result.isFailure) {
@@ -297,7 +297,7 @@ class WspulseClient
         }
 
         /**
-         * Read incoming WebSocket frames, decode, and dispatch to onMessage.
+         * Read incoming WebSocket messages, decode, and dispatch to onMessage.
          *
          * Completes [dropped] when the transport's incoming channel closes (transport drop).
          */
@@ -332,15 +332,15 @@ class WspulseClient
                         break
                     }
 
-                    val frame: Frame
+                    val message: Message
                     try {
-                        frame = config.codec.decode(data)
+                        message = config.codec.decode(data)
                     } catch (e: Exception) {
-                        logger.warn("wspulse/client: decode failed, frame dropped", e)
+                        logger.warn("wspulse/client: decode failed, message dropped", e)
                         continue
                     }
                     try {
-                        config.onMessage(frame)
+                        config.onMessage(message)
                     } catch (e: Exception) {
                         logger.warn("wspulse/client: onMessage callback threw", e)
                     }
@@ -371,9 +371,9 @@ class WspulseClient
                     if (!scope.isActive) return
 
                     val wsFrame =
-                        when (config.codec.frameType) {
-                            FrameType.TEXT -> TransportFrame.Text(String(data, Charsets.UTF_8))
-                            FrameType.BINARY -> TransportFrame.Binary(data)
+                        when (config.codec.wireType) {
+                            WireType.TEXT -> TransportFrame.Text(String(data, Charsets.UTF_8))
+                            WireType.BINARY -> TransportFrame.Binary(data)
                         }
 
                     try {

--- a/src/test/kotlin/com/wspulse/client/CodecTest.kt
+++ b/src/test/kotlin/com/wspulse/client/CodecTest.kt
@@ -8,8 +8,8 @@ import kotlin.test.assertNull
 class CodecTest {
     @Test
     fun `round-trip encode and decode`() {
-        val frame = Frame(event = "chat", payload = mapOf("msg" to "hello"))
-        val decoded = JsonCodec.decode(JsonCodec.encode(frame))
+        val message = Message(event = "chat", payload = mapOf("msg" to "hello"))
+        val decoded = JsonCodec.decode(JsonCodec.encode(message))
 
         assertEquals("chat", decoded.event)
         assertEquals(mapOf("msg" to "hello"), decoded.payload)
@@ -17,8 +17,8 @@ class CodecTest {
 
     @Test
     fun `null fields are omitted from JSON output`() {
-        val frame = Frame() // all fields null
-        val json = String(JsonCodec.encode(frame), Charsets.UTF_8)
+        val message = Message() // all fields null
+        val json = String(JsonCodec.encode(message), Charsets.UTF_8)
 
         assertEquals("{}", json)
     }
@@ -26,10 +26,10 @@ class CodecTest {
     @Test
     fun `unknown keys in JSON are ignored on decode`() {
         val json = """{"event":"e","payload":"v","extra":"ignored"}"""
-        val frame = JsonCodec.decode(json.toByteArray(Charsets.UTF_8))
+        val message = JsonCodec.decode(json.toByteArray(Charsets.UTF_8))
 
-        assertEquals("e", frame.event)
-        assertEquals("v", frame.payload)
+        assertEquals("e", message.event)
+        assertEquals("v", message.payload)
     }
 
     @Test
@@ -39,8 +39,8 @@ class CodecTest {
                 "user" to mapOf("name" to "alice", "age" to 30),
                 "tags" to listOf("a", "b"),
             )
-        val frame = Frame(payload = payload)
-        val decoded = JsonCodec.decode(JsonCodec.encode(frame))
+        val message = Message(payload = payload)
+        val decoded = JsonCodec.decode(JsonCodec.encode(message))
 
         @Suppress("UNCHECKED_CAST")
         val decodedPayload = decoded.payload as Map<String, Any?>
@@ -53,44 +53,44 @@ class CodecTest {
     }
 
     @Test
-    fun `empty frame decodes from empty JSON object`() {
-        val frame = JsonCodec.decode("{}".toByteArray(Charsets.UTF_8))
+    fun `empty message decodes from empty JSON object`() {
+        val message = JsonCodec.decode("{}".toByteArray(Charsets.UTF_8))
 
-        assertNull(frame.event)
-        assertNull(frame.payload)
+        assertNull(message.event)
+        assertNull(message.payload)
     }
 
     @Test
     fun `string payload`() {
-        val frame = Frame(payload = "hello")
-        val decoded = JsonCodec.decode(JsonCodec.encode(frame))
+        val message = Message(payload = "hello")
+        val decoded = JsonCodec.decode(JsonCodec.encode(message))
         assertEquals("hello", decoded.payload)
     }
 
     @Test
     fun `boolean payload`() {
-        val frame = Frame(payload = true)
-        val decoded = JsonCodec.decode(JsonCodec.encode(frame))
+        val message = Message(payload = true)
+        val decoded = JsonCodec.decode(JsonCodec.encode(message))
         assertEquals(true, decoded.payload)
     }
 
     @Test
     fun `list payload`() {
-        val frame = Frame(payload = listOf(1, "two", false))
-        val decoded = JsonCodec.decode(JsonCodec.encode(frame))
+        val message = Message(payload = listOf(1, "two", false))
+        val decoded = JsonCodec.decode(JsonCodec.encode(message))
         assertEquals(listOf(1, "two", false), decoded.payload)
     }
 
     @Test
-    fun `frameType is TEXT`() {
-        assertEquals(FrameType.TEXT, JsonCodec.frameType)
+    fun `wireType is TEXT`() {
+        assertEquals(WireType.TEXT, JsonCodec.wireType)
     }
 
     @Test
     fun `encode with unsupported payload type throws`() {
-        val frame = Frame(payload = object {})
+        val message = Message(payload = object {})
         assertThrows<IllegalArgumentException> {
-            JsonCodec.encode(frame)
+            JsonCodec.encode(message)
         }
     }
 
@@ -103,8 +103,8 @@ class CodecTest {
 
     @Test
     fun `null value in map payload round-trips`() {
-        val frame = Frame(payload = mapOf("key" to null))
-        val decoded = JsonCodec.decode(JsonCodec.encode(frame))
+        val message = Message(payload = mapOf("key" to null))
+        val decoded = JsonCodec.decode(JsonCodec.encode(message))
 
         @Suppress("UNCHECKED_CAST")
         val payload = decoded.payload as Map<String, Any?>
@@ -113,8 +113,8 @@ class CodecTest {
 
     @Test
     fun `null value in list payload round-trips`() {
-        val frame = Frame(payload = listOf("a", null, "b"))
-        val decoded = JsonCodec.decode(JsonCodec.encode(frame))
+        val message = Message(payload = listOf("a", null, "b"))
+        val decoded = JsonCodec.decode(JsonCodec.encode(message))
         assertEquals(listOf("a", null, "b"), decoded.payload)
     }
 }

--- a/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/BasicTest.kt
@@ -1,6 +1,6 @@
 package com.wspulse.client.component
 
-import com.wspulse.client.Frame
+import com.wspulse.client.Message
 import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
 import com.wspulse.client.WspulseException
@@ -26,9 +26,9 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
     // ── Scenario 1: connect, send, receive echo, close ──────────────────────
 
     @Test
-    fun `connects, sends a frame, receives echo, and closes cleanly`() =
+    fun `connects, sends a message, receives echo, and closes cleanly`() =
         runTest(StandardTestDispatcher(testScheduler)) {
-            val received = CopyOnWriteArrayList<Frame>()
+            val received = CopyOnWriteArrayList<Message>()
             val disconnectErr = AtomicReference<WspulseException?>(null)
             val disconnectCalled = CompletableDeferred<Unit>()
             val transportDropFired = CompletableDeferred<Unit>()
@@ -43,7 +43,7 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
                 WspulseClient.connectInternal(
                     "ws://test",
                     clientConfig {
-                        onMessage = { frame -> received.add(frame) }
+                        onMessage = { msg -> received.add(msg) }
                         onTransportDrop = { err ->
                             transportDropWasNull.set(err == null)
                             transportDropFired.complete(Unit)
@@ -58,10 +58,10 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
                 )
             testClient = client
 
-            // Client sends a frame.
-            client.send(Frame(event = "msg", payload = mapOf("text" to "hello")))
+            // Client sends a message.
+            client.send(Message(event = "msg", payload = mapOf("text" to "hello")))
 
-            // Wait for writeLoop to pick up the frame.
+            // Wait for writeLoop to pick up the message.
             waitUntil { transport.sent.any { it is TransportFrame.Text } }
 
             // Simulate server echo.
@@ -84,12 +84,12 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
             assertNull(disconnectErr.get())
         }
 
-    // ── Frame round-trip ────────────────────────────────────────────────────
+    // ── Message round-trip ──────────────────────────────────────────────────
 
     @Test
-    fun `round-trips all Frame fields (event, payload)`() =
+    fun `round-trips all Message fields (event, payload)`() =
         runTest(StandardTestDispatcher(testScheduler)) {
-            val received = CopyOnWriteArrayList<Frame>()
+            val received = CopyOnWriteArrayList<Message>()
 
             val transport = MockTransport()
             val dialer = MockDialer(listOf(Result.success(transport)))
@@ -97,14 +97,14 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
             val client =
                 WspulseClient.connectInternal(
                     "ws://test",
-                    clientConfig { onMessage = { frame -> received.add(frame) } },
+                    clientConfig { onMessage = { msg -> received.add(msg) } },
                     dialer,
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
             testClient = client
 
             val outbound =
-                Frame(
+                Message(
                     event = "chat.message",
                     payload =
                         mapOf(
@@ -157,9 +157,9 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
     // ── Message ordering ────────────────────────────────────────────────────
 
     @Test
-    fun `sends multiple frames and receives them in order`() =
+    fun `sends multiple messages and receives them in order`() =
         runTest(StandardTestDispatcher(testScheduler)) {
-            val received = CopyOnWriteArrayList<Frame>()
+            val received = CopyOnWriteArrayList<Message>()
 
             val transport = MockTransport()
             val dialer = MockDialer(listOf(Result.success(transport)))
@@ -167,7 +167,7 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
             val client =
                 WspulseClient.connectInternal(
                     "ws://test",
-                    clientConfig { onMessage = { frame -> received.add(frame) } },
+                    clientConfig { onMessage = { msg -> received.add(msg) } },
                     dialer,
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
@@ -175,7 +175,7 @@ class BasicTest : ComponentTestBase(TestCoroutineScheduler()) {
 
             val count = 10
             for (i in 0 until count) {
-                client.send(Frame(event = "seq", payload = mapOf("i" to i)))
+                client.send(Message(event = "seq", payload = mapOf("i" to i)))
             }
 
             // Wait for all writes.

--- a/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/LifecycleTest.kt
@@ -1,7 +1,7 @@
 package com.wspulse.client.component
 
 import com.wspulse.client.ConnectionClosedException
-import com.wspulse.client.Frame
+import com.wspulse.client.Message
 import com.wspulse.client.WspulseClient
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
@@ -40,7 +40,7 @@ class LifecycleTest : ComponentTestBase(TestCoroutineScheduler()) {
             client.close()
             client.done.await()
 
-            assertThrows<ConnectionClosedException> { client.send(Frame(event = "msg")) }
+            assertThrows<ConnectionClosedException> { client.send(Message(event = "msg")) }
         }
 
     // ── Close idempotency ───────────────────────────────────────────────────

--- a/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MiscTest.kt
@@ -1,6 +1,6 @@
 package com.wspulse.client.component
 
-import com.wspulse.client.Frame
+import com.wspulse.client.Message
 import com.wspulse.client.TransportFrame
 import com.wspulse.client.WspulseClient
 import kotlinx.coroutines.async
@@ -25,7 +25,7 @@ class MiscTest : ComponentTestBase(TestCoroutineScheduler()) {
     @Test
     fun `concurrent sends from multiple coroutines do not race`() =
         runTest(StandardTestDispatcher(testScheduler)) {
-            val received = CopyOnWriteArrayList<Frame>()
+            val received = CopyOnWriteArrayList<Message>()
 
             val transport = MockTransport()
             val dialer = MockDialer(listOf(Result.success(transport)))
@@ -33,7 +33,7 @@ class MiscTest : ComponentTestBase(TestCoroutineScheduler()) {
             val client =
                 WspulseClient.connectInternal(
                     "ws://test",
-                    clientConfig { onMessage = { frame -> received.add(frame) } },
+                    clientConfig { onMessage = { msg -> received.add(msg) } },
                     dialer,
                     dispatcher = UnconfinedTestDispatcher(testScheduler),
                 )
@@ -49,7 +49,7 @@ class MiscTest : ComponentTestBase(TestCoroutineScheduler()) {
                     async {
                         for (m in 0 until msgsPerSender) {
                             client.send(
-                                Frame(
+                                Message(
                                     event = "concurrent",
                                     payload = mapOf("s" to s, "m" to m),
                                 ),

--- a/src/test/kotlin/com/wspulse/client/component/MockTransport.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MockTransport.kt
@@ -41,7 +41,7 @@ internal class MockTransport : Transport {
 
     // ── test injection helpers ──────────────────────────────────────────────
 
-    /** Inject a text frame (simulates server sending a message). */
+    /** Inject a text message (simulates server sending a message). */
     fun injectText(data: String) {
         incomingChannel.trySend(TransportFrame.Text(data)).getOrThrow()
     }

--- a/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/ReconnectTest.kt
@@ -2,7 +2,7 @@ package com.wspulse.client.component
 
 import com.wspulse.client.AutoReconnectConfig
 import com.wspulse.client.Dialer
-import com.wspulse.client.Frame
+import com.wspulse.client.Message
 import com.wspulse.client.RetriesExhaustedException
 import com.wspulse.client.Transport
 import com.wspulse.client.TransportFrame
@@ -36,7 +36,7 @@ class ReconnectTest : ComponentTestBase(TestCoroutineScheduler()) {
     @Test
     fun `reconnects after transport drop and resumes message flow`() =
         runTest(StandardTestDispatcher(testScheduler)) {
-            val received = CopyOnWriteArrayList<Frame>()
+            val received = CopyOnWriteArrayList<Message>()
             val transportRestored = CompletableDeferred<Unit>()
 
             val transport1 = MockTransport()
@@ -48,7 +48,7 @@ class ReconnectTest : ComponentTestBase(TestCoroutineScheduler()) {
                 WspulseClient.connectInternal(
                     "ws://test",
                     clientConfig {
-                        onMessage = { frame -> received.add(frame) }
+                        onMessage = { msg -> received.add(msg) }
                         onTransportRestore = { transportRestored.complete(Unit) }
                         autoReconnect =
                             AutoReconnectConfig(
@@ -63,8 +63,8 @@ class ReconnectTest : ComponentTestBase(TestCoroutineScheduler()) {
                 )
             testClient = client
 
-            // Send a frame before drop.
-            client.send(Frame(event = "before", payload = "drop"))
+            // Send a message before drop.
+            client.send(Message(event = "before", payload = "drop"))
             waitUntil { transport1.sent.any { it is TransportFrame.Text } }
             transport1.injectText("""{"event":"before","payload":"drop"}""")
             waitUntil { received.any { it.event == "before" } }
@@ -79,7 +79,7 @@ class ReconnectTest : ComponentTestBase(TestCoroutineScheduler()) {
             assertTrue(transportRestored.isCompleted)
 
             // Send after reconnect.
-            client.send(Frame(event = "after", payload = "reconnect"))
+            client.send(Message(event = "after", payload = "reconnect"))
             waitUntil { transport2.sent.any { it is TransportFrame.Text } }
             transport2.injectText("""{"event":"after","payload":"reconnect"}""")
             waitUntil { received.any { it.event == "after" } }


### PR DESCRIPTION
## Summary

Rename application-layer `Frame` to `Message` and `FrameType` to `WireType` across the entire client-kt module, aligning with the upstream wspulse/core rename.

## Related issues

Closes #30
Relates to wspulse/.github#34

## Changes

- Renamed `data class Frame` to `data class Message` (file: `Frame.kt` -> `Message.kt`)
- Renamed `enum class FrameType` to `enum class WireType` in `Codec.kt`
- Renamed `Codec.frameType` property to `Codec.wireType`
- Renamed `Codec.encode(frame: Frame)` parameter to `Codec.encode(message: Message)`
- Renamed `Client.send(frame: Frame)` to `Client.send(message: Message)`
- Updated `ClientConfig.onMessage` type from `(Frame) -> Unit` to `(Message) -> Unit`
- Updated all test files (CodecTest, BasicTest, LifecycleTest, MiscTest, ReconnectTest, MockTransport)
- Updated comments: application-layer "frame" -> "message" (WebSocket protocol-layer "frame" unchanged)
- Updated README.md: code examples, API surface table, client options table
- Updated CHANGELOG.md with [Unreleased] breaking change entries
- Updated AGENTS.md and `.github/copilot-instructions.md` architecture sections
- `TransportFrame`, `TransportCloseReason`, and all WebSocket protocol-layer types unchanged

## Checklist

### Required

- [x] `make check` passes (lint -> test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: major version bump discussed in linked issue