### PR TITLE
feat: preserve server close frame code and reason in ServerClosedException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- `ServerClosedException` — passed to `ClientConfig.onTransportDrop` when the server sends a WebSocket close frame. Exposes `code: StatusCode` and `reason: String` read directly from the close frame.
+- `StatusCode` — inline value class wrapping RFC 6455 §7.4 close codes. Companion constants (`NORMAL_CLOSURE`, `GOING_AWAY`, etc.); custom codes in the `4000`–`4999` private-use range are valid. See [wspulse/.github#37](https://github.com/wspulse/.github/issues/37).
+
 ## [0.6.0] - 2026-04-16
 
 ### Removed

--- a/src/main/kotlin/com/wspulse/client/Errors.kt
+++ b/src/main/kotlin/com/wspulse/client/Errors.kt
@@ -29,3 +29,29 @@ class ConnectionLostException(
         if (cause != null) initCause(cause)
     }
 }
+
+/**
+ * Thrown when the server sends a WebSocket close frame.
+ *
+ * Carries the close code and reason read directly from the frame so callers can
+ * distinguish disconnect causes (e.g. `GOING_AWAY` vs `POLICY_VIOLATION`).
+ *
+ * Delivered to [ClientConfig.onTransportDrop] as the cause. Pseudo-codes
+ * [StatusCode.NO_STATUS_RECEIVED] (1005) and [StatusCode.ABNORMAL_CLOSURE] (1006)
+ * are NOT reported through this exception — they surface as a generic
+ * [ConnectionLostException].
+ */
+class ServerClosedException(
+    val code: StatusCode,
+    val reason: String,
+) : WspulseException(
+        buildString {
+            append("wspulse: server closed connection: code=")
+            append(code.value)
+            if (reason.isNotEmpty()) {
+                append(", reason=\"")
+                append(reason)
+                append('"')
+            }
+        },
+    )

--- a/src/main/kotlin/com/wspulse/client/Errors.kt
+++ b/src/main/kotlin/com/wspulse/client/Errors.kt
@@ -36,15 +36,23 @@ class ConnectionLostException(
  * Carries the close code and reason read directly from the frame so callers can
  * distinguish disconnect causes (e.g. `GOING_AWAY` vs `POLICY_VIOLATION`).
  *
- * Delivered to [ClientConfig.onTransportDrop] as the cause. Pseudo-codes
+ * Delivered to [ClientConfig.onTransportDrop] as the cause when a concrete
+ * WebSocket close frame is received. Pseudo-codes
  * [StatusCode.NO_STATUS_RECEIVED] (1005) and [StatusCode.ABNORMAL_CLOSURE] (1006)
- * are NOT reported through this exception — they surface as a generic
- * [ConnectionLostException].
+ * are not exposed through this exception. In those cases,
+ * [ClientConfig.onTransportDrop] may instead observe a generic transport-drop
+ * exception, for example `Exception("wspulse: transport closed unexpectedly")`.
  */
 class ServerClosedException(
     val code: StatusCode,
     val reason: String,
 ) : WspulseException(
+        // The `reason` is interpolated without escaping. This is intentional:
+        // the exception message is for human-readable logging only, and callers
+        // that need structured access read the typed `code`/`reason` fields
+        // directly. Pulling in org.json.JSONObject.quote (or equivalent) to
+        // escape quotes/control characters in the message is not worth the
+        // dependency cost for a diagnostic-only string.
         buildString {
             append("wspulse: server closed connection: code=")
             append(code.value)

--- a/src/main/kotlin/com/wspulse/client/StatusCode.kt
+++ b/src/main/kotlin/com/wspulse/client/StatusCode.kt
@@ -14,6 +14,12 @@ package com.wspulse.client
 value class StatusCode(
     val value: Int,
 ) {
+    init {
+        require(value in 0..0xFFFF) {
+            "wspulse: StatusCode value must be in 0..65535, got $value"
+        }
+    }
+
     override fun toString(): String = value.toString()
 
     companion object {

--- a/src/main/kotlin/com/wspulse/client/StatusCode.kt
+++ b/src/main/kotlin/com/wspulse/client/StatusCode.kt
@@ -1,0 +1,66 @@
+package com.wspulse.client
+
+/**
+ * WebSocket close status code (RFC 6455 §7.4).
+ *
+ * Wraps the raw 16-bit integer close code. Callers use the [Companion]
+ * constants for standard codes or construct directly for application-specific
+ * codes in the private-use range `4000`–`4999`.
+ *
+ * The inline value class keeps runtime overhead at zero while giving the API
+ * a typed, self-documenting form.
+ */
+@JvmInline
+value class StatusCode(
+    val value: Int,
+) {
+    override fun toString(): String = value.toString()
+
+    companion object {
+        /** 1000 — Normal closure; the connection completed its purpose. */
+        val NORMAL_CLOSURE = StatusCode(1000)
+
+        /** 1001 — Endpoint is going away (server shutdown, browser navigation). */
+        val GOING_AWAY = StatusCode(1001)
+
+        /** 1002 — Protocol error. */
+        val PROTOCOL_ERROR = StatusCode(1002)
+
+        /** 1003 — Received data type the endpoint cannot accept. */
+        val UNSUPPORTED_DATA = StatusCode(1003)
+
+        /**
+         * 1005 — No status code was present in the close frame.
+         *
+         * RFC 6455 §7.4.1: MUST NOT be sent on the wire; the client library
+         * synthesizes this value when a received close frame has no status body.
+         */
+        val NO_STATUS_RECEIVED = StatusCode(1005)
+
+        /**
+         * 1006 — Connection closed abnormally without a close frame.
+         *
+         * RFC 6455 §7.4.1: MUST NOT be sent on the wire; synthesized by the
+         * implementation when the TCP connection drops without a close handshake.
+         */
+        val ABNORMAL_CLOSURE = StatusCode(1006)
+
+        /** 1007 — Received payload not consistent with message type (e.g. invalid UTF-8). */
+        val INVALID_FRAME_PAYLOAD_DATA = StatusCode(1007)
+
+        /** 1008 — Message violates endpoint policy. */
+        val POLICY_VIOLATION = StatusCode(1008)
+
+        /** 1009 — Message too large for the endpoint to process. */
+        val MESSAGE_TOO_BIG = StatusCode(1009)
+
+        /** 1010 — Client expected the server to negotiate required extensions. */
+        val MANDATORY_EXTENSION = StatusCode(1010)
+
+        /** 1011 — Server encountered an unexpected condition. */
+        val INTERNAL_ERROR = StatusCode(1011)
+
+        /** 1015 — TLS handshake failed. Synthesized by the implementation; never on the wire. */
+        val TLS_HANDSHAKE = StatusCode(1015)
+    }
+}

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -314,7 +314,20 @@ class WspulseClient
                         when (wsFrame) {
                             is TransportFrame.Text -> wsFrame.data.toByteArray(Charsets.UTF_8)
                             is TransportFrame.Binary -> wsFrame.data
-                            else -> continue
+                            is TransportFrame.Close -> {
+                                // Server-initiated close frame. Preserve the code and reason
+                                // so onTransportDrop can distinguish disconnect causes.
+                                // Pseudo-codes NO_STATUS_RECEIVED (1005) and ABNORMAL_CLOSURE
+                                // (1006) indicate no real close frame was received; surface
+                                // those as a generic transport drop instead.
+                                val code = wsFrame.code.toInt() and 0xFFFF
+                                if (code != StatusCode.NO_STATUS_RECEIVED.value &&
+                                    code != StatusCode.ABNORMAL_CLOSURE.value
+                                ) {
+                                    readError = ServerClosedException(StatusCode(code), wsFrame.reason)
+                                }
+                                break
+                            }
                         }
 
                     // maxMessageSize enforcement.

--- a/src/test/kotlin/com/wspulse/client/ErrorsTest.kt
+++ b/src/test/kotlin/com/wspulse/client/ErrorsTest.kt
@@ -2,6 +2,7 @@ package com.wspulse.client
 
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -51,5 +52,29 @@ class ErrorsTest {
         assertIs<WspulseException>(SendBufferFullException())
         assertIs<WspulseException>(RetriesExhaustedException(1))
         assertIs<WspulseException>(ConnectionLostException())
+        assertIs<WspulseException>(ServerClosedException(StatusCode.NORMAL_CLOSURE, ""))
+    }
+
+    @Test
+    fun `ServerClosedException carries code and reason`() {
+        val ex = ServerClosedException(StatusCode.GOING_AWAY, "server shutting down")
+        assertEquals(StatusCode.GOING_AWAY, ex.code)
+        assertEquals("server shutting down", ex.reason)
+    }
+
+    @Test
+    fun `ServerClosedException message includes code and reason`() {
+        val ex = ServerClosedException(StatusCode.GOING_AWAY, "bye")
+        assertTrue(ex.message!!.startsWith("wspulse:"))
+        assertTrue(ex.message!!.contains("1001"))
+        assertTrue(ex.message!!.contains("bye"))
+    }
+
+    @Test
+    fun `ServerClosedException with empty reason omits it from message`() {
+        val ex = ServerClosedException(StatusCode.NORMAL_CLOSURE, "")
+        assertTrue(ex.message!!.startsWith("wspulse:"))
+        assertTrue(ex.message!!.contains("1000"))
+        assertFalse(ex.message!!.contains("reason="))
     }
 }

--- a/src/test/kotlin/com/wspulse/client/StatusCodeTest.kt
+++ b/src/test/kotlin/com/wspulse/client/StatusCodeTest.kt
@@ -1,0 +1,36 @@
+package com.wspulse.client
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class StatusCodeTest {
+    @Test
+    fun `StatusCode rejects negative values`() {
+        assertFailsWith<IllegalArgumentException> {
+            StatusCode(-1)
+        }
+    }
+
+    @Test
+    fun `StatusCode rejects values above 65535`() {
+        assertFailsWith<IllegalArgumentException> {
+            StatusCode(65536)
+        }
+    }
+
+    @Test
+    fun `StatusCode accepts lower boundary 0`() {
+        assertEquals(0, StatusCode(0).value)
+    }
+
+    @Test
+    fun `StatusCode accepts upper boundary 65535`() {
+        assertEquals(65535, StatusCode(65535).value)
+    }
+
+    @Test
+    fun `StatusCode accepts private-use range value`() {
+        assertEquals(4000, StatusCode(4000).value)
+    }
+}

--- a/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
@@ -354,4 +354,41 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
             secondRestoreCalled.await()
             assertEquals(2, restoreCount.get())
         }
+
+    // ── Server close frame delivers ServerClosedException ───────────────────
+
+    @Test
+    fun `server close frame delivers ServerClosedException with code and reason`() =
+        runTest(StandardTestDispatcher(testScheduler)) {
+            val transportDropErr = AtomicReference<Exception?>(null)
+            val transportDropped = CompletableDeferred<Unit>()
+
+            val transport = MockTransport()
+            val dialer = MockDialer(listOf(Result.success(transport)))
+
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onTransportDrop = { err ->
+                            transportDropErr.set(err)
+                            transportDropped.complete(Unit)
+                        }
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
+
+            // Simulate server close frame.
+            transport.injectCloseFrame(1001, "server shutting down")
+
+            transportDropped.await()
+
+            val err = transportDropErr.get()
+            assertTrue(err is com.wspulse.client.ServerClosedException, "expected ServerClosedException, got $err")
+            val sce = err as com.wspulse.client.ServerClosedException
+            assertEquals(1001, sce.code.value)
+            assertEquals("server shutting down", sce.reason)
+        }
 }

--- a/src/test/kotlin/com/wspulse/client/component/MockTransport.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MockTransport.kt
@@ -53,6 +53,17 @@ internal class MockTransport : Transport {
         }
     }
 
+    /** Inject a WebSocket close frame (simulates server-initiated close with code and reason). */
+    fun injectCloseFrame(
+        code: Int,
+        reason: String,
+    ) {
+        incomingChannel.trySend(TransportFrame.Close(code.toShort(), reason)).getOrThrow()
+        if (closedFlag.compareAndSet(false, true)) {
+            incomingChannel.close()
+        }
+    }
+
     /** Close the incoming channel with an error (simulates transport error). */
     fun injectError(cause: Exception = Exception("mock transport error")) {
         if (closedFlag.compareAndSet(false, true)) {


### PR DESCRIPTION
## Summary

Preserve the WebSocket close frame code and reason in a new `ServerClosedException` so reconnect callbacks can distinguish server-initiated disconnect causes (e.g. going away vs policy violation) instead of seeing a generic `WspulseException`.

## Related issues

Relates to wspulse/.github#37

## Changes

- Add `StatusCode.kt` as a `@JvmInline value class` with companion constants for RFC 6455 codes (zero-cost boxing, leaves the 4000-4999 private-use range open).
- Add `ServerClosedException(code: StatusCode, reason: String) : WspulseException` in `Errors.kt` with message format `wspulse: server closed connection: code=N[, reason="..."]`.
- In `WspulseClient.kt` `readLoop`, when a `TransportFrame.Close` is received, mask the code to 16 bits and — unless it is `NO_STATUS_RECEIVED` (1005) or `ABNORMAL_CLOSURE` (1006), which are not real frames — set `readError = ServerClosedException(...)` and break.
- Tests: four new unit tests in `ErrorsTest.kt`; one new component test in `component/CallbackTest.kt` via a new `MockTransport.injectCloseFrame(code: Int, reason: String)` helper.
- CHANGELOG updated.

## Checklist

### Required

- [x] `make check` passes (lint → test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] New public API: includes KDoc comments
