### PR TITLE
release: v0.8.0

### DIFF
--- a/.github/workflows/pr-to-main-gate.yml
+++ b/.github/workflows/pr-to-main-gate.yml
@@ -1,4 +1,4 @@
-name: Changelog Gate
+name: PR to Main Gate
 
 on:
   workflow_dispatch:
@@ -8,3 +8,25 @@ on:
 jobs:
   changelog-gate:
     uses: wspulse/.github/.github/workflows/changelog-gate.yml@main
+
+  version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Version consistency check
+        run: |
+          set -euo pipefail
+          # Find the first versioned (non-Unreleased) entry in CHANGELOG.md.
+          CHANGELOG_VER=$(grep '## \[' CHANGELOG.md | { grep -v 'Unreleased' || true; } | head -1 | sed 's/## \[\(.*\)\].*/\1/')
+          if [ -z "$CHANGELOG_VER" ]; then
+            echo "No versioned entry found in CHANGELOG.md — nothing to check"
+            exit 0
+          fi
+          GRADLE_VER=$(grep '^version = ' build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
+          if [ "$GRADLE_VER" != "$CHANGELOG_VER" ]; then
+            echo "Mismatch: build.gradle.kts=$GRADLE_VER, CHANGELOG=$CHANGELOG_VER"
+            exit 1
+          fi
+          echo "All versions match: $CHANGELOG_VER"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- `ServerClosedException` — passed to `ClientConfig.onTransportDrop` when the server sends a WebSocket close frame. Exposes `code: StatusCode` and `reason: String` read directly from the close frame.
+- `StatusCode` — inline value class wrapping RFC 6455 §7.4 close codes. Companion constants (`NORMAL_CLOSURE`, `GOING_AWAY`, etc.); custom codes in the `4000`–`4999` private-use range are valid. See [wspulse/.github#37](https://github.com/wspulse/.github/issues/37).
+
 ## [0.6.0] - 2026-04-16
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-02
+
 ### Added
 
 - `ServerClosedException` — passed to `ClientConfig.onTransportDrop` when the server sends a WebSocket close frame. Exposes `code: StatusCode` and `reason: String` read directly from the close frame.
@@ -124,7 +126,8 @@
 - CI workflow: JDK 17 + 21 matrix, `./gradlew check`
 - README with quick-start, Android ViewModel example, API reference
 
-[Unreleased]: https://github.com/wspulse/client-kt/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/wspulse/client-kt/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/wspulse/client-kt/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/wspulse/client-kt/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/wspulse/client-kt/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/wspulse/client-kt/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Added
 
 - `ServerClosedException` — passed to `ClientConfig.onTransportDrop` when the server sends a WebSocket close frame. Exposes `code: StatusCode` and `reason: String` read directly from the close frame.
-- `StatusCode` — inline value class wrapping RFC 6455 §7.4 close codes. Companion constants (`NORMAL_CLOSURE`, `GOING_AWAY`, etc.); custom codes in the `4000`–`4999` private-use range are valid. See [wspulse/.github#37](https://github.com/wspulse/.github/issues/37).
+- `StatusCode` — inline value class wrapping RFC 6455 §7.4 close codes. Companion constants (`NORMAL_CLOSURE`, `GOING_AWAY`, etc.); accepts any 16-bit close code (0–65535) so all server-sent codes are representable. Application-defined codes typically use the `4000`–`4999` private-use range. See [wspulse/.github#37](https://github.com/wspulse/.github/issues/37).
 
 ## [0.7.0] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added
 
-- `ServerClosedException` — passed to `ClientConfig.onTransportDrop` when the server sends a WebSocket close frame. Exposes `code: StatusCode` and `reason: String` read directly from the close frame.
+- **BREAKING**: `ServerClosedException` — new subclass of the public sealed `WspulseException` hierarchy; passed to `ClientConfig.onTransportDrop` when the server sends a WebSocket close frame. Exposes `code: StatusCode` and `reason: String` as reported by the WebSocket layer (1005 `NO_STATUS_RECEIVED` is synthesized when the close frame has no status body). See [wspulse/.github#37](https://github.com/wspulse/.github/issues/37).
 - `StatusCode` — inline value class wrapping RFC 6455 §7.4 close codes. Companion constants (`NORMAL_CLOSURE`, `GOING_AWAY`, etc.); accepts any 16-bit close code (0–65535) so all server-sent codes are representable. Application-defined codes typically use the `4000`–`4999` private-use range. See [wspulse/.github#37](https://github.com/wspulse/.github/issues/37).
 
 ## [0.7.0] - 2026-04-21

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ dependencies {
 | --------------------------- | ------------------------- |
 | `ConnectionClosedException` | `send()` after `close()`  |
 | `SendBufferFullException`   | `send()` when buffer full |
+| `ServerClosedException`     | `onTransportDrop` when server sends a close frame (carries `code` and `reason`) |
 | `RetriesExhaustedException` | `onDisconnect`            |
 | `ConnectionLostException`   | `onDisconnect`            |
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ val client = WspulseClient.connect(url) {
 | `Codec`         | Interface: `encode()`, `decode()`, `wireType`        |
 | `JsonCodec`     | Default codec — JSON text frames                     |
 | `ClientConfig`  | Builder DSL for client configuration                 |
+| `StatusCode`    | Inline value class wrapping an RFC 6455 close code; companion holds named constants (`NORMAL_CLOSURE`, `GOING_AWAY`, etc.) |
 
 ### Client Options
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.wspulse"
-version = "0.6.0"
+version = "0.8.0"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/wspulse/client/ClientConfig.kt
+++ b/src/main/kotlin/com/wspulse/client/ClientConfig.kt
@@ -33,6 +33,10 @@ class ClientConfig {
      *
      * Fires with `null` on a clean [Client.close] call, or with the transport error on unexpected
      * drops. When [Client.close] is called while reconnecting, this callback does not fire again.
+     *
+     * When the server initiates the close with a status code and reason, the argument is a
+     * [ServerClosedException] — inspect its [ServerClosedException.code] and
+     * [ServerClosedException.reason] fields to distinguish close causes.
      */
     var onTransportDrop: (Exception?) -> Unit = {}
 

--- a/src/main/kotlin/com/wspulse/client/Errors.kt
+++ b/src/main/kotlin/com/wspulse/client/Errors.kt
@@ -48,18 +48,15 @@ class ServerClosedException(
     val code: StatusCode,
     val reason: String,
 ) : WspulseException(
-        // The `reason` is interpolated without escaping. This is intentional:
-        // the exception message is for human-readable logging only, and callers
-        // that need structured access read the typed `code`/`reason` fields
-        // directly. Pulling in org.json.JSONObject.quote (or equivalent) to
-        // escape quotes/control characters in the message is not worth the
-        // dependency cost for a diagnostic-only string.
         buildString {
             append("wspulse: server closed connection: code=")
             append(code.value)
             if (reason.isNotEmpty()) {
+                // Strip control characters (newlines, tabs, etc.) to prevent log injection.
+                // Callers that need the raw reason read the typed `reason` field directly.
+                val sanitized = reason.replace(Regex("\\p{Cntrl}+"), "?")
                 append(", reason=\"")
-                append(reason)
+                append(sanitized)
                 append('"')
             }
         },

--- a/src/main/kotlin/com/wspulse/client/Errors.kt
+++ b/src/main/kotlin/com/wspulse/client/Errors.kt
@@ -29,3 +29,29 @@ class ConnectionLostException(
         if (cause != null) initCause(cause)
     }
 }
+
+/**
+ * Thrown when the server sends a WebSocket close frame.
+ *
+ * Carries the close code and reason read directly from the frame so callers can
+ * distinguish disconnect causes (e.g. `GOING_AWAY` vs `POLICY_VIOLATION`).
+ *
+ * Delivered to [ClientConfig.onTransportDrop] as the cause. Pseudo-codes
+ * [StatusCode.NO_STATUS_RECEIVED] (1005) and [StatusCode.ABNORMAL_CLOSURE] (1006)
+ * are NOT reported through this exception — they surface as a generic
+ * [ConnectionLostException].
+ */
+class ServerClosedException(
+    val code: StatusCode,
+    val reason: String,
+) : WspulseException(
+        buildString {
+            append("wspulse: server closed connection: code=")
+            append(code.value)
+            if (reason.isNotEmpty()) {
+                append(", reason=\"")
+                append(reason)
+                append('"')
+            }
+        },
+    )

--- a/src/main/kotlin/com/wspulse/client/Errors.kt
+++ b/src/main/kotlin/com/wspulse/client/Errors.kt
@@ -37,11 +37,12 @@ class ConnectionLostException(
  * distinguish disconnect causes (e.g. `GOING_AWAY` vs `POLICY_VIOLATION`).
  *
  * Delivered to [ClientConfig.onTransportDrop] as the cause when a concrete
- * WebSocket close frame is received. Pseudo-codes
- * [StatusCode.NO_STATUS_RECEIVED] (1005) and [StatusCode.ABNORMAL_CLOSURE] (1006)
- * are not exposed through this exception. In those cases,
- * [ClientConfig.onTransportDrop] may instead observe a generic transport-drop
- * exception, for example `Exception("wspulse: transport closed unexpectedly")`.
+ * WebSocket close frame is received, including when the frame carries no status
+ * body ([StatusCode.NO_STATUS_RECEIVED], 1005).
+ *
+ * Only [StatusCode.ABNORMAL_CLOSURE] (1006) is excluded — that code indicates
+ * a TCP drop without any close handshake, and is surfaced as
+ * [ConnectionLostException] instead.
  */
 class ServerClosedException(
     val code: StatusCode,

--- a/src/main/kotlin/com/wspulse/client/Errors.kt
+++ b/src/main/kotlin/com/wspulse/client/Errors.kt
@@ -36,15 +36,23 @@ class ConnectionLostException(
  * Carries the close code and reason read directly from the frame so callers can
  * distinguish disconnect causes (e.g. `GOING_AWAY` vs `POLICY_VIOLATION`).
  *
- * Delivered to [ClientConfig.onTransportDrop] as the cause. Pseudo-codes
+ * Delivered to [ClientConfig.onTransportDrop] as the cause when a concrete
+ * WebSocket close frame is received. Pseudo-codes
  * [StatusCode.NO_STATUS_RECEIVED] (1005) and [StatusCode.ABNORMAL_CLOSURE] (1006)
- * are NOT reported through this exception — they surface as a generic
- * [ConnectionLostException].
+ * are not exposed through this exception. In those cases,
+ * [ClientConfig.onTransportDrop] may instead observe a generic transport-drop
+ * exception, for example `Exception("wspulse: transport closed unexpectedly")`.
  */
 class ServerClosedException(
     val code: StatusCode,
     val reason: String,
 ) : WspulseException(
+        // The `reason` is interpolated without escaping. This is intentional:
+        // the exception message is for human-readable logging only, and callers
+        // that need structured access read the typed `code`/`reason` fields
+        // directly. Pulling in org.json.JSONObject.quote (or equivalent) to
+        // escape quotes/control characters in the message is not worth the
+        // dependency cost for a diagnostic-only string.
         buildString {
             append("wspulse: server closed connection: code=")
             append(code.value)

--- a/src/main/kotlin/com/wspulse/client/StatusCode.kt
+++ b/src/main/kotlin/com/wspulse/client/StatusCode.kt
@@ -14,6 +14,12 @@ package com.wspulse.client
 value class StatusCode(
     val value: Int,
 ) {
+    init {
+        require(value in 0..0xFFFF) {
+            "wspulse: StatusCode value must be in 0..65535, got $value"
+        }
+    }
+
     override fun toString(): String = value.toString()
 
     companion object {

--- a/src/main/kotlin/com/wspulse/client/StatusCode.kt
+++ b/src/main/kotlin/com/wspulse/client/StatusCode.kt
@@ -1,0 +1,66 @@
+package com.wspulse.client
+
+/**
+ * WebSocket close status code (RFC 6455 §7.4).
+ *
+ * Wraps the raw 16-bit integer close code. Callers use the [Companion]
+ * constants for standard codes or construct directly for application-specific
+ * codes in the private-use range `4000`–`4999`.
+ *
+ * The inline value class keeps runtime overhead at zero while giving the API
+ * a typed, self-documenting form.
+ */
+@JvmInline
+value class StatusCode(
+    val value: Int,
+) {
+    override fun toString(): String = value.toString()
+
+    companion object {
+        /** 1000 — Normal closure; the connection completed its purpose. */
+        val NORMAL_CLOSURE = StatusCode(1000)
+
+        /** 1001 — Endpoint is going away (server shutdown, browser navigation). */
+        val GOING_AWAY = StatusCode(1001)
+
+        /** 1002 — Protocol error. */
+        val PROTOCOL_ERROR = StatusCode(1002)
+
+        /** 1003 — Received data type the endpoint cannot accept. */
+        val UNSUPPORTED_DATA = StatusCode(1003)
+
+        /**
+         * 1005 — No status code was present in the close frame.
+         *
+         * RFC 6455 §7.4.1: MUST NOT be sent on the wire; the client library
+         * synthesizes this value when a received close frame has no status body.
+         */
+        val NO_STATUS_RECEIVED = StatusCode(1005)
+
+        /**
+         * 1006 — Connection closed abnormally without a close frame.
+         *
+         * RFC 6455 §7.4.1: MUST NOT be sent on the wire; synthesized by the
+         * implementation when the TCP connection drops without a close handshake.
+         */
+        val ABNORMAL_CLOSURE = StatusCode(1006)
+
+        /** 1007 — Received payload not consistent with message type (e.g. invalid UTF-8). */
+        val INVALID_FRAME_PAYLOAD_DATA = StatusCode(1007)
+
+        /** 1008 — Message violates endpoint policy. */
+        val POLICY_VIOLATION = StatusCode(1008)
+
+        /** 1009 — Message too large for the endpoint to process. */
+        val MESSAGE_TOO_BIG = StatusCode(1009)
+
+        /** 1010 — Client expected the server to negotiate required extensions. */
+        val MANDATORY_EXTENSION = StatusCode(1010)
+
+        /** 1011 — Server encountered an unexpected condition. */
+        val INTERNAL_ERROR = StatusCode(1011)
+
+        /** 1015 — TLS handshake failed. Synthesized by the implementation; never on the wire. */
+        val TLS_HANDSHAKE = StatusCode(1015)
+    }
+}

--- a/src/main/kotlin/com/wspulse/client/StatusCode.kt
+++ b/src/main/kotlin/com/wspulse/client/StatusCode.kt
@@ -4,8 +4,9 @@ package com.wspulse.client
  * WebSocket close status code (RFC 6455 §7.4).
  *
  * Wraps the raw 16-bit integer close code. Callers use the [Companion]
- * constants for standard codes or construct directly for application-specific
- * codes in the private-use range `4000`–`4999`.
+ * constants for standard codes. The constructor accepts any 16-bit value
+ * (0–65535) so the library can represent any close code received from the
+ * server; application-defined codes are typically in the `4000`–`4999` range.
  *
  * The inline value class keeps runtime overhead at zero while giving the API
  * a typed, self-documenting form.
@@ -46,8 +47,8 @@ value class StatusCode(
         /**
          * 1006 — Connection closed abnormally without a close frame.
          *
-         * RFC 6455 §7.4.1: MUST NOT be sent on the wire; synthesized by the
-         * implementation when the TCP connection drops without a close handshake.
+         * RFC 6455 §7.4.1: MUST NOT be sent on the wire. Surfaced when the
+         * TCP connection drops without a close handshake.
          */
         val ABNORMAL_CLOSURE = StatusCode(1006)
 

--- a/src/main/kotlin/com/wspulse/client/StatusCode.kt
+++ b/src/main/kotlin/com/wspulse/client/StatusCode.kt
@@ -3,22 +3,21 @@ package com.wspulse.client
 /**
  * WebSocket close status code (RFC 6455 §7.4).
  *
- * Wraps the raw 16-bit integer close code. Callers use the [Companion]
- * constants for standard codes. The constructor accepts any 16-bit value
- * (0–65535) so the library can represent any close code received from the
- * server; application-defined codes are typically in the `4000`–`4999` range.
+ * Wraps the raw 16-bit integer close code. [Companion] exposes constants for the standard codes
+ * that have defined semantics in this library. The constructor accepts any 16-bit value (0–65535)
+ * so callers can represent any code received from the server; constants are not provided for
+ * reserved or rarely-used entries — use `StatusCode(n)` directly for those. Application-defined
+ * codes are typically in the `4000`–`4999` range.
  *
- * The inline value class keeps runtime overhead at zero while giving the API
- * a typed, self-documenting form.
+ * The inline value class keeps runtime overhead at zero while giving the API a typed,
+ * self-documenting form.
  */
 @JvmInline
 value class StatusCode(
     val value: Int,
 ) {
     init {
-        require(value in 0..0xFFFF) {
-            "wspulse: StatusCode value must be in 0..65535, got $value"
-        }
+        require(value in 0..0xFFFF) { "wspulse: StatusCode value must be in 0..65535, got $value" }
     }
 
     override fun toString(): String = value.toString()
@@ -39,16 +38,16 @@ value class StatusCode(
         /**
          * 1005 — No status code was present in the close frame.
          *
-         * RFC 6455 §7.4.1: MUST NOT be sent on the wire; the client library
-         * synthesizes this value when a received close frame has no status body.
+         * RFC 6455 §7.4.1: MUST NOT be sent on the wire; the client library synthesizes this value
+         * when a received close frame has no status body.
          */
         val NO_STATUS_RECEIVED = StatusCode(1005)
 
         /**
          * 1006 — Connection closed abnormally without a close frame.
          *
-         * RFC 6455 §7.4.1: MUST NOT be sent on the wire. Surfaced when the
-         * TCP connection drops without a close handshake.
+         * RFC 6455 §7.4.1: MUST NOT be sent on the wire. Surfaced when the TCP connection drops
+         * without a close handshake.
          */
         val ABNORMAL_CLOSURE = StatusCode(1006)
 
@@ -67,7 +66,13 @@ value class StatusCode(
         /** 1011 — Server encountered an unexpected condition. */
         val INTERNAL_ERROR = StatusCode(1011)
 
-        /** 1015 — TLS handshake failed. Synthesized by the implementation; never on the wire. */
+        /**
+         * 1015 — TLS handshake failure.
+         *
+         * RFC 6455 §7.4.1: MUST NOT be sent on the wire. Defined here as a constant
+         * for callers matching codes received from non-compliant peers; this library
+         * does not synthesize it internally.
+         */
         val TLS_HANDSHAKE = StatusCode(1015)
     }
 }

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -317,13 +317,14 @@ class WspulseClient
                             is TransportFrame.Close -> {
                                 // Server-initiated close frame. Preserve the code and reason
                                 // so onTransportDrop can distinguish disconnect causes.
-                                // Pseudo-codes NO_STATUS_RECEIVED (1005) and ABNORMAL_CLOSURE
-                                // (1006) indicate no real close frame was received; surface
-                                // those as a generic transport drop instead.
+                                // Only ABNORMAL_CLOSURE (1006) indicates no real close frame
+                                // was received (TCP drop); surface that as a generic transport
+                                // drop instead.
+                                // NO_STATUS_RECEIVED (1005) means a close frame WAS received
+                                // but without a status body — still a real server-initiated
+                                // close, per RFC 6455 §7.1.5.
                                 val code = wsFrame.code.toInt() and 0xFFFF
-                                if (code != StatusCode.NO_STATUS_RECEIVED.value &&
-                                    code != StatusCode.ABNORMAL_CLOSURE.value
-                                ) {
+                                if (code != StatusCode.ABNORMAL_CLOSURE.value) {
                                     readError = ServerClosedException(StatusCode(code), wsFrame.reason)
                                 }
                                 break

--- a/src/main/kotlin/com/wspulse/client/WspulseClient.kt
+++ b/src/main/kotlin/com/wspulse/client/WspulseClient.kt
@@ -314,7 +314,20 @@ class WspulseClient
                         when (wsFrame) {
                             is TransportFrame.Text -> wsFrame.data.toByteArray(Charsets.UTF_8)
                             is TransportFrame.Binary -> wsFrame.data
-                            else -> continue
+                            is TransportFrame.Close -> {
+                                // Server-initiated close frame. Preserve the code and reason
+                                // so onTransportDrop can distinguish disconnect causes.
+                                // Pseudo-codes NO_STATUS_RECEIVED (1005) and ABNORMAL_CLOSURE
+                                // (1006) indicate no real close frame was received; surface
+                                // those as a generic transport drop instead.
+                                val code = wsFrame.code.toInt() and 0xFFFF
+                                if (code != StatusCode.NO_STATUS_RECEIVED.value &&
+                                    code != StatusCode.ABNORMAL_CLOSURE.value
+                                ) {
+                                    readError = ServerClosedException(StatusCode(code), wsFrame.reason)
+                                }
+                                break
+                            }
                         }
 
                     // maxMessageSize enforcement.

--- a/src/test/kotlin/com/wspulse/client/ErrorsTest.kt
+++ b/src/test/kotlin/com/wspulse/client/ErrorsTest.kt
@@ -2,6 +2,7 @@ package com.wspulse.client
 
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -51,5 +52,29 @@ class ErrorsTest {
         assertIs<WspulseException>(SendBufferFullException())
         assertIs<WspulseException>(RetriesExhaustedException(1))
         assertIs<WspulseException>(ConnectionLostException())
+        assertIs<WspulseException>(ServerClosedException(StatusCode.NORMAL_CLOSURE, ""))
+    }
+
+    @Test
+    fun `ServerClosedException carries code and reason`() {
+        val ex = ServerClosedException(StatusCode.GOING_AWAY, "server shutting down")
+        assertEquals(StatusCode.GOING_AWAY, ex.code)
+        assertEquals("server shutting down", ex.reason)
+    }
+
+    @Test
+    fun `ServerClosedException message includes code and reason`() {
+        val ex = ServerClosedException(StatusCode.GOING_AWAY, "bye")
+        assertTrue(ex.message!!.startsWith("wspulse:"))
+        assertTrue(ex.message!!.contains("1001"))
+        assertTrue(ex.message!!.contains("bye"))
+    }
+
+    @Test
+    fun `ServerClosedException with empty reason omits it from message`() {
+        val ex = ServerClosedException(StatusCode.NORMAL_CLOSURE, "")
+        assertTrue(ex.message!!.startsWith("wspulse:"))
+        assertTrue(ex.message!!.contains("1000"))
+        assertFalse(ex.message!!.contains("reason="))
     }
 }

--- a/src/test/kotlin/com/wspulse/client/StatusCodeTest.kt
+++ b/src/test/kotlin/com/wspulse/client/StatusCodeTest.kt
@@ -1,0 +1,36 @@
+package com.wspulse.client
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class StatusCodeTest {
+    @Test
+    fun `StatusCode rejects negative values`() {
+        assertFailsWith<IllegalArgumentException> {
+            StatusCode(-1)
+        }
+    }
+
+    @Test
+    fun `StatusCode rejects values above 65535`() {
+        assertFailsWith<IllegalArgumentException> {
+            StatusCode(65536)
+        }
+    }
+
+    @Test
+    fun `StatusCode accepts lower boundary 0`() {
+        assertEquals(0, StatusCode(0).value)
+    }
+
+    @Test
+    fun `StatusCode accepts upper boundary 65535`() {
+        assertEquals(65535, StatusCode(65535).value)
+    }
+
+    @Test
+    fun `StatusCode accepts private-use range value`() {
+        assertEquals(4000, StatusCode(4000).value)
+    }
+}

--- a/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
@@ -391,4 +391,44 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
             assertEquals(1001, sce.code.value)
             assertEquals("server shutting down", sce.reason)
         }
+
+    @Test
+    fun `close frame with no status body (1005) delivers ServerClosedException`() =
+        runTest(StandardTestDispatcher(testScheduler)) {
+            val transportDropErr = AtomicReference<Exception?>(null)
+            val transportDropped = CompletableDeferred<Unit>()
+
+            val transport = MockTransport()
+            val dialer = MockDialer(listOf(Result.success(transport)))
+
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onTransportDrop = { err ->
+                            transportDropErr.set(err)
+                            transportDropped.complete(Unit)
+                        }
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
+
+            // Simulate a close frame with no status body — RFC 6455 §7.4.1 synthesises
+            // code 1005 (NO_STATUS_RECEIVED). Must surface as ServerClosedException,
+            // not be swallowed or collapsed into a generic error.
+            transport.injectCloseFrame(1005, "")
+
+            transportDropped.await()
+
+            val err = transportDropErr.get()
+            assertTrue(
+                err is com.wspulse.client.ServerClosedException,
+                "1005 should surface as ServerClosedException, got $err",
+            )
+            val sce = err as com.wspulse.client.ServerClosedException
+            assertEquals(1005, sce.code.value)
+            assertEquals("", sce.reason)
+        }
 }

--- a/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
@@ -354,4 +354,41 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
             secondRestoreCalled.await()
             assertEquals(2, restoreCount.get())
         }
+
+    // ── Server close frame delivers ServerClosedException ───────────────────
+
+    @Test
+    fun `server close frame delivers ServerClosedException with code and reason`() =
+        runTest(StandardTestDispatcher(testScheduler)) {
+            val transportDropErr = AtomicReference<Exception?>(null)
+            val transportDropped = CompletableDeferred<Unit>()
+
+            val transport = MockTransport()
+            val dialer = MockDialer(listOf(Result.success(transport)))
+
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onTransportDrop = { err ->
+                            transportDropErr.set(err)
+                            transportDropped.complete(Unit)
+                        }
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
+
+            // Simulate server close frame.
+            transport.injectCloseFrame(1001, "server shutting down")
+
+            transportDropped.await()
+
+            val err = transportDropErr.get()
+            assertTrue(err is com.wspulse.client.ServerClosedException, "expected ServerClosedException, got $err")
+            val sce = err as com.wspulse.client.ServerClosedException
+            assertEquals(1001, sce.code.value)
+            assertEquals("server shutting down", sce.reason)
+        }
 }

--- a/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
+++ b/src/test/kotlin/com/wspulse/client/component/CallbackTest.kt
@@ -431,4 +431,42 @@ class CallbackTest : ComponentTestBase(TestCoroutineScheduler()) {
             assertEquals(1005, sce.code.value)
             assertEquals("", sce.reason)
         }
+
+    @Test
+    fun `ServerClosedException message strips control characters from reason`() =
+        runTest(StandardTestDispatcher(testScheduler)) {
+            val transportDropErr = AtomicReference<Exception?>(null)
+            val transportDropped = CompletableDeferred<Unit>()
+
+            val transport = MockTransport()
+            val dialer = MockDialer(listOf(Result.success(transport)))
+
+            val client =
+                WspulseClient.connectInternal(
+                    "ws://test",
+                    clientConfig {
+                        onTransportDrop = { err ->
+                            transportDropErr.set(err)
+                            transportDropped.complete(Unit)
+                        }
+                    },
+                    dialer,
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            testClient = client
+
+            // Inject a reason that contains control characters (newline, tab, NUL).
+            // The sanitized exception message must not contain them — prevents log injection.
+            transport.injectCloseFrame(1001, "bad\nreason\u0000here")
+
+            transportDropped.await()
+
+            val err = transportDropErr.get()
+            val sce = err as com.wspulse.client.ServerClosedException
+            // Raw field is preserved for callers that need the original value.
+            assertEquals("bad\nreason\u0000here", sce.reason)
+            // Exception message must have control characters stripped.
+            assertFalse(sce.message!!.contains('\n'), "message must not contain newline")
+            assertFalse(sce.message!!.contains('\u0000'), "message must not contain NUL")
+        }
 }

--- a/src/test/kotlin/com/wspulse/client/component/MockTransport.kt
+++ b/src/test/kotlin/com/wspulse/client/component/MockTransport.kt
@@ -53,6 +53,17 @@ internal class MockTransport : Transport {
         }
     }
 
+    /** Inject a WebSocket close frame (simulates server-initiated close with code and reason). */
+    fun injectCloseFrame(
+        code: Int,
+        reason: String,
+    ) {
+        incomingChannel.trySend(TransportFrame.Close(code.toShort(), reason)).getOrThrow()
+        if (closedFlag.compareAndSet(false, true)) {
+            incomingChannel.close()
+        }
+    }
+
     /** Close the incoming channel with an error (simulates transport error). */
     fun injectError(cause: Exception = Exception("mock transport error")) {
         if (closedFlag.compareAndSet(false, true)) {


### PR DESCRIPTION
## Summary

Release v0.8.0 — preserve server close frame code and reason in `ServerClosedException`.

## Related issues

Closes #33

## Changes

- **BREAKING**: Add `ServerClosedException` (with `code: StatusCode` and `reason: String`) passed to `ClientConfig.onTransportDrop` when the server sends a WebSocket close frame
- Add `StatusCode` inline value class with RFC 6455 §7.4 companion constants
- Update `CallbackTest` to assert close code and reason are preserved
- Add `ErrorsTest` and `StatusCodeTest` for direct coverage
- Promote `[Unreleased]` to `[0.8.0] - 2026-05-02` in CHANGELOG
- Update comparison links

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: this is a v0.x project; breaking changes in minor releases are documented with `**BREAKING**` in CHANGELOG per project convention